### PR TITLE
fix(ci): 修復 Release 工作流程的語法和邏輯

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,9 +76,11 @@ jobs:
         sleep 30
         
         # 檢查套件是否存在於 PyPI
-        for i in {1..5}; do
+        for i in {1..5};
+        do
           echo "⏳ Attempt $i/5: Checking PyPI availability..."
-          if curl -f -s "https://pypi.org/pypi/$PACKAGE_NAME/$VERSION/json" > /dev/null; then
+          if curl -f -s "https://pypi.org/pypi/$PACKAGE_NAME/$VERSION/json" > /dev/null;
+          then
             echo "✅ Package $PACKAGE_NAME version $VERSION is available on PyPI!"
             echo "🔗 PyPI URL: https://pypi.org/project/$PACKAGE_NAME/$VERSION/"
             break
@@ -87,7 +89,8 @@ jobs:
             sleep 30
           fi
           
-          if [ $i -eq 5 ]; then
+          if [ $i -eq 5 ];
+          then
             echo "❌ Package not found on PyPI after 5 attempts"
             exit 1
           fi
@@ -111,7 +114,7 @@ jobs:
         echo "### 🔄 Upgrade Command" >> $GITHUB_STEP_SUMMARY
         echo '```bash' >> $GITHUB_STEP_SUMMARY
         echo "pip install --upgrade redshift-comment-mcp" >> $GITHUB_STEP_SUMMARY
-        echo '```' >> $GITHUB_STEP_SUMMARY
+        echo '```'
 
     - name: Add comment to release
       if: github.event_name == 'release' && success()
@@ -123,30 +126,29 @@ jobs:
           const installCmd = `pip install redshift-comment-mcp==${version}`;
           const upgradeCmd = `pip install --upgrade redshift-comment-mcp`;
           
-          const body = `## 🚀 PyPI 發布成功！
+          const body = '## 🚀 PyPI 發布成功！\n\n' +
+            '**版本**: ' + version + '\n' +
+            '**PyPI 頁面**: ' + pypiUrl + '\n\n' +
+            '### 📥 安裝指令\n' +
+            '```bash\n' +
+            installCmd + '\n' +
+            '```\n\n' +
+            '### 🔄 升級指令\n' +
+            '```bash\n' +
+            upgradeCmd + '\n' +
+            '```\n\n' +
+            '### 📚 使用指南\n' +
+            '查看 [README.md](https://github.com/' + context.repo.owner + '/' + context.repo.repo + '#readme) 了解詳細的使用方式。\n\n' +
+            '---\n' +
+            '🤖 *此訊息由 GitHub Actions 自動生成*';
 
-**版本**: ${version}
-**PyPI 頁面**: ${pypiUrl}
-
-### 📥 安裝指令
-\`\`\`bash
-${installCmd}
-\`\`\`
-
-### 🔄 升級指令
-\`\`\`bash
-${upgradeCmd}
-\`\`\`
-
-### 📚 使用指南
-查看 [README.md](https://github.com/${context.repo.owner}/${context.repo.repo}#readme) 了解詳細的使用方式。
-
----
-🤖 *此訊息由 GitHub Actions 自動生成*`;
-
-          github.rest.issues.createComment({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.payload.release.discussion_number,
-            body: body
-          });
+          if (context.payload.release.discussion) {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.release.discussion.number,
+              body: body
+            });
+          } else {
+            console.log("No associated discussion found for this release. Skipping comment.");
+          }

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -76,9 +76,11 @@ jobs:
         sleep 30
         
         # 檢查套件是否存在於 TestPyPI
-        for i in {1..5}; do
+        for i in {1..5};
+        do
           echo "⏳ Attempt $i/5: Checking TestPyPI availability..."
-          if curl -f -s "https://test.pypi.org/pypi/$PACKAGE_NAME/$VERSION/json" > /dev/null; then
+          if curl -f -s "https://test.pypi.org/pypi/$PACKAGE_NAME/$VERSION/json" > /dev/null;
+          then
             echo "✅ Package $PACKAGE_NAME version $VERSION is available on TestPyPI!"
             echo "🔗 TestPyPI URL: https://test.pypi.org/project/$PACKAGE_NAME/$VERSION/"
             break
@@ -87,7 +89,8 @@ jobs:
             sleep 30
           fi
           
-          if [ $i -eq 5 ]; then
+          if [ $i -eq 5 ];
+          then
             echo "❌ Package not found on TestPyPI after 5 attempts"
             exit 1
           fi
@@ -139,21 +142,17 @@ jobs:
           const testPypiUrl = `https://test.pypi.org/project/redshift-comment-mcp/${version}/`;
           const installCmd = `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ redshift-comment-mcp==${version}`;
           
-          const body = `## 🎉 TestPyPI 發布成功！
-
-**版本**: ${version}
-**TestPyPI 頁面**: ${testPypiUrl}
-
-### 📥 測試安裝
-\`\`\`bash
-${installCmd}
-\`\`\`
-
-### 🔄 下一步
-如果測試無誤，請將此 Pre-release 轉為正式 Release 以觸發 PyPI 發布。
-
----
-🤖 *此訊息由 GitHub Actions 自動生成*`;
+          const body = '## 🎉 TestPyPI 發布成功！\n\n' +
+            '**版本**: ' + version + '\n' +
+            '**TestPyPI 頁面**: ' + testPypiUrl + '\n\n' +
+            '### 📥 測試安裝\n' +
+            '```bash\n' +
+            installCmd + '\n' +
+            '```\n\n' +
+            '### 🔄 下一步\n' +
+            '如果測試無誤，請將此 Pre-release 轉為正式 Release 以觸發 PyPI 發布。\n\n' +
+            '---' +
+            '🤖 *此訊息由 GitHub Actions 自動生成*';
 
           if (context.payload.release.discussion) {
             await github.rest.issues.createComment({


### PR DESCRIPTION
修復了 `publish.yml` 和 `test-publish.yml` 工作流程中的兩個問題：

1.  解決了 `github-script` 步驟中因巢狀反引號導致的 YAML 語法錯誤。透過將 `body` 字串的建立方式從模板字串改為標準的字串串接，避免了 YAML 解析器的混淆。

2.  增強了 `publish.yml` 的穩健性。現在它會在使用 `discussion.number` 之前，先檢查 `release` 是否有關聯的 `discussion`，從而避免在沒有關聯討論時發生錯誤。
