### PR TITLE
fix(ci): 防止 publish 工作流程在 pre-release 時執行

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,7 @@ jobs:
 
   publish:
     needs: test
+    if: github.event.release.prerelease == false
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
在 `publish` 作業中增加了 `if: github.event.release.prerelease == false` 條件。

這確保了正式發布的工作流程只會在建立正式版 Release 時運行，而不會在建立 Pre-release 時被錯誤地觸發。
