### PR TITLE
fix(build): set fallback_version for plugin cache installs (no .git)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redshift-comment-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Redshift MCP server with comment-first exploration. 11 tools for schema/table/column listing, hit-count keyword search, and SELECT-only SQL. Comments are authoritative — names are unreliable. Multi-cluster via named profiles. Plugin uses the cloned repo source directly (no PyPI release prerequisite); run `uvx --from \"git+https://github.com/kouko/redshift-comment-mcp.git\" redshift-comment-mcp setup` once after install to configure your profile.",
   "author": {
     "name": "kouko",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,5 +42,9 @@ dev = [
 redshift-comment-mcp = "redshift_comment_mcp.server:main"
 
 # setuptools-scm 自動版本管理
+# fallback_version: 給沒有 .git 的安裝路徑（例如 Claude Code plugin cache、
+# sdist tarball、Docker build context）一個確定的版本號。發新版時請與
+# .claude-plugin/plugin.json 的 "version" 欄位一同更新。
 [tool.setuptools_scm]
 write_to = "src/redshift_comment_mcp/_version.py"
+fallback_version = "0.2.1"


### PR DESCRIPTION
## Summary
- Adds `fallback_version = "0.2.1"` to `[tool.setuptools_scm]` so installs without `.git` (Claude Code plugin cache, sdist tarballs, Docker build context) don't abort with `setuptools_scm was unable to detect version`.
- Bumps plugin manifest `.claude-plugin/plugin.json` version `0.2.0` → `0.2.1`.

## Why
Claude Code clones the plugin into `~/.claude/plugins/cache/<name>/<version>/` without the source repo's `.git` directory. `setuptools_scm` has nothing to read at install time, the editable build fails, and every downstream `uv run --project <plugin-cache> ...` call (the setup CLI's `set-fields` / `test-connection`, the MCP server `${CLAUDE_PLUGIN_ROOT}` invocation in `plugin.json`) hits the same wall. Local dev installs (with `.git`) are unaffected.

Reproduced as: invoking `/redshift-setup` on a fresh plugin install fails at Step 3 / Step 5 with `setuptools_scm was unable to detect version → fall back to a default ...`.

## Test plan
- [x] Sandbox repro: `rsync` source → `rm -rf .git` → `uv run --project <sandbox> redshift-comment-mcp list-profiles` builds and exits 0 (without any `SETUPTOOLS_SCM_PRETEND_VERSION_*` env var).
- [x] Local dev repro: `git describe --tags` still reports `v0.2.0-14-gc55f925`; SCM-derived dev version still computed when `.git` is present.
- [x] Plugin cache repro: copied modified `pyproject.toml` into `~/.claude/plugins/cache/.../0.2.0/`, deleted `.venv` implicitly by reinstall, `list-profiles` builds and exits 0.
- [ ] Post-merge: bump local clone, reinstall plugin, confirm `/redshift-setup` runs end-to-end without env-var workaround.

## Memory
### Decision
Chose `fallback_version` over dropping `setuptools_scm` entirely. Local dev keeps post-tag version info (e.g. `0.2.0.post14+gc55f925`) which is useful for bug reports; consumers without `.git` get a clean static fallback. Cost is one extra place to bump on each release — release flow now touches three artifacts: git tag, `.claude-plugin/plugin.json` `version`, and `pyproject.toml` `fallback_version`. The comment above `[tool.setuptools_scm]` flags the coupling so future-me notices.

### Gotchas
- Claude Code's plugin cache strips `.git` when cloning. Any build-time tool that reads git history (`setuptools_scm`, `hatch-vcs`, `dunamai`) will fail at editable-install time in plugin contexts. If we ever swap build backends, re-test this code path.
- `fallback_version` only kicks in when `.git` is absent. If `.git` exists but tags are missing (shallow clone with `--depth 1`), `setuptools_scm` reports a different error — not solved here.

### Learnings
- `fallback_version` is a top-level option in `[tool.setuptools_scm]`, not a hidden flag. Single-line addition; no setuptools-side change needed.
- The plugin manifest already stores version in `.claude-plugin/plugin.json` independently of Python packaging, so consumers were already living with two sources of truth — adding `fallback_version` makes it three but doesn't introduce a new coordination problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)