### PR TITLE
refactor(skills): trim descriptions + add anti-patterns/see-also; redesign redshift-setup

### DIFF
--- a/skills/redshift-cache-schema/SKILL.md
+++ b/skills/redshift-cache-schema/SKILL.md
@@ -1,20 +1,13 @@
 ---
 name: redshift-cache-schema
 description: >-
-  Dump Redshift cluster structure (schemas / tables / columns / comments)
-  as markdown under ~/.cache/redshift-comment-mcp/<profile>/ for offline
-  browsing — give analysts a directory of files to read instead of
-  re-issuing MCP queries every conversation. Cache (rebuildable from
-  live DB), NOT wiki (no synthesis, no hand-edits). Idempotent.
-  Use when user invokes /redshift-cache-schema, or says: "cache the
-  schema", "dump redshift structure", "offline schema browse", "save
-  metadata", "把 schema dump 下來", "離線瀏覽", "結構快取", "把 table
-  抓下來放本地", "快取 metadata", "schema を キャッシュ", "メタデータを
-  ローカルに", "スキーマ ダンプ", "オフライン参照". Do NOT use for:
-  persistent hand-edited docs (that's a wiki — separate plugin),
-  synthesis / stale-tracking (out of charter), exporting row data
-  (only structure is cached), one-off questions (use list_* directly),
-  clusters with hundreds of tables without --scope.
+  Dump Redshift cluster structure to local markdown for offline
+  browsing. Read-only, idempotent. Use when user wants the schema
+  cached locally (flaky VPN, onboarding handoff, offline audit).
+  Do NOT use for hand-edited docs (use a wiki plugin), row-data
+  export, or one-off questions (use list_* directly). Triggers:
+  /redshift-cache-schema / cache schema / dump structure / 結構快取
+  / 離線瀏覽 / オフライン参照.
 ---
 
 # Redshift Schema Cache
@@ -110,6 +103,14 @@ No row counts / samples in cache files — structure only by design.
 ```
 `--dry-run` lists filenames that would be written; no disk writes.
 
+## Anti-patterns
+
+- NEVER hand-edit cached files — they're regenerable; next refresh clobbers edits. Use a separate wiki plugin for persistent notes.
+- NEVER auto-prune `_orphans/` — they're the forensic trace when a DB drop happens. Let the user decide removal.
+- NEVER move out-of-scope orphans on partial `--scope` runs — silently corrupts cache for schemas the user did not touch.
+- NEVER convert `nullable` from raw `"YES"`/`"NO"` to bool — downstream tools rely on the raw MCP shape; conversion causes "works for me" bugs.
+- NEVER cache row data — charter is structure only; a billion-row table would exhaust local disk before the user notices.
+
 ## Errors
 | Condition | Behavior |
 |---|---|
@@ -120,3 +121,12 @@ No row counts / samples in cache files — structure only by design.
 | Full cache without --scope, > 50 schemas | `_error: scope_too_large` |
 
 Cache dir created with `mkdir -p`, mode 700.
+
+## See also
+
+| Need | Use |
+|---|---|
+| Interactive schema walk (lighter than full cache) | `/redshift-explore` |
+| Visualize FK relationships | `/redshift-erd` |
+| Turn cached structure into dbt yml drafts | `/redshift-suggest-schema-yml` |
+| Mine actual usage from query history | `/redshift-lineage-from-stl` |

--- a/skills/redshift-erd/SKILL.md
+++ b/skills/redshift-erd/SKILL.md
@@ -2,19 +2,14 @@
 name: redshift-erd
 description: >-
   Generate a Mermaid erDiagram for a Redshift schema with tables, key
-  columns, and FK relationships. FK source priority: pg_constraint
-  (HIGH) → dbt manifest depends_on (MEDIUM, if --manifest passed) →
-  naming heuristic `<other>_id` (LOW). Edges labeled with confidence.
-  Read-only. Use when user invokes /redshift-erd, or says: "ERD for",
-  "draw the schema", "table relationships", "foreign keys", "show me
-  how tables connect", "畫個 ERD", "看 table 關係", "schema 關係圖",
-  "FK 推論", "外鍵關係", "ER 図", "リレーション図", "テーブル関係",
-  "外部キー推論", "スキーマ可視化". Do NOT use for: column-level
-  lineage (use /redshift-lineage-from-stl), single-table inspection
-  (use /redshift-explore Step 3 or list_columns directly), schemas
-  with > 30 tables without --tables filter (output unreadable; refuse),
-  validating production constraints (Redshift does NOT enforce FKs —
-  they're advisory only).
+  columns, and confidence-labeled FK relationships. Read-only. Use
+  when user wants to map an unfamiliar schema visually, before
+  drilling into individual tables. Do NOT use for column-level lineage
+  (use /redshift-lineage-from-stl), single-table inspection (use
+  /redshift-explore), or validating production FKs (Redshift declares
+  but does not enforce them). Triggers: /redshift-erd / ERD / table
+  relationships / foreign keys / 畫個 ERD / 關係圖 / ER 図 /
+  リレーション図.
 ---
 
 # Redshift ERD
@@ -108,6 +103,14 @@ markdown) + edge rationale table:
 Footer: "Drew N tables, M edges (X HIGH / Y MEDIUM / Z LOW). Heuristic
 edges are guesses — verify before trusting."
 
+## Anti-patterns
+
+- NEVER claim FK constraints are enforced — Redshift declares but does not validate. Always render confidence tier in the edge label.
+- NEVER assume `pg_constraint` works on every cluster — `unnest WITH ORDINALITY` fails on some Redshift versions. On error, drop to MEDIUM/LOW silently and add a footer note.
+- NEVER infer multi-column FKs from naming — single-column `<other>_id` heuristic only. Multi-column tells need `pg_constraint`.
+- NEVER set non-default cardinality (e.g. `}|--||`) without reading actual constraint metadata — catalog cardinality is unreliable; default `}o--||`.
+- NEVER hide LOW-confidence edges silently, but DO truncate to top-N when count > 100 — visual noise crowds out HIGH edges.
+
 ## Errors
 | Condition | Behavior |
 |---|---|
@@ -116,3 +119,11 @@ edges are guesses — verify before trusting."
 | `--manifest` path missing | `_error: manifest_not_found: <path>` |
 | Heuristic > 100 edges | warn, render top-N by confidence + frequency |
 | Scope > 30 without filter | `_error: scope_too_large` |
+
+## See also
+
+| Need | Use |
+|---|---|
+| Find tables before drawing | `/redshift-explore` |
+| Offline structure browse | `/redshift-cache-schema` |
+| Actual runtime data flow (vs declared FKs) | `/redshift-lineage-from-stl` |

--- a/skills/redshift-explore/SKILL.md
+++ b/skills/redshift-explore/SKILL.md
@@ -1,20 +1,14 @@
 ---
 name: redshift-explore
 description: >-
-  Three-step interactive wizard for exploring a Redshift cluster from
-  zero context: schema → table → column, each step listing candidates
-  with comments so the user picks by reading, not by remembering names.
-  Hands off to /redshift-profile on the chosen column. Makes the implementation_guide.md "Guided Data Discovery"
-  charter explicit. Use when user invokes /redshift-explore, or says:
-  "I don't know where to start", "explore the warehouse", "browse
-  Redshift", "where do I look", "找一下這個 cluster", "我不知道要看
-  哪個 table", "從哪開始", "guide me through", "走一遍 schema",
-  "Redshift を探検", "どのテーブルか分からない", "探したい",
-  "ガイド付き探索". Do NOT use when user already knows the table.column
-  (use /redshift-profile directly), in
-  non-interactive contexts (wizard requires human picks), for
-  schema-wide reporting (use /redshift-cache-schema), or batch
-  question answering (intentionally conversational).
+  Interactive walkthrough for an unfamiliar Redshift cluster — schema
+  → table → column, picked by reading comments. Hands off to
+  /redshift-profile. Use when user doesn't know where to start in a
+  cluster. Do NOT use when user already knows the table.column (use
+  /redshift-profile directly), in non-interactive contexts, or for
+  schema-wide reporting (use /redshift-cache-schema). Triggers:
+  /redshift-explore / browse Redshift / where do I look / 找 cluster
+  / 從哪開始 / 探検 / ガイド付き探索.
 ---
 
 # Redshift Guided Explore
@@ -100,6 +94,14 @@ Custom question: answer directly using the MCP tools that fit.
 Wizard prose IS the output. No JSON block — interactive by design.
 Step 4 produces the downstream skill's output.
 
+## Anti-patterns
+
+- NEVER skip the comment-first render even when the user named a table — the rendering IS the value. If the answer is already known, hand off to the right sister skill instead of running the wizard.
+- NEVER show > 50 candidates per step — paginate. Comment-first reading scales worse than alphabetical.
+- NEVER call `search_columns` without both `schema_name` AND `table_name` — MCP rejects wildcard scope; user gets a cryptic error.
+- NEVER auto-execute Step 4 option (a) without an explicit pick — handoff to `/redshift-profile` changes the workflow contract.
+- NEVER strip empty-comment items — render as `(no comment)` so the user sees what to ask the data owner about.
+
 ## Errors
 | Condition | Behavior |
 |---|---|
@@ -108,3 +110,11 @@ Step 4 produces the downstream skill's output.
 | Picked table has no columns | `_error: no_columns` (likely permission) |
 | Reply matches no candidate / keyword | re-render with hint |
 | User says cancel / quit | exit cleanly, no error |
+
+## See also
+
+| Need | Use |
+|---|---|
+| Profile a column once you have it | `/redshift-profile` |
+| Visualize a whole schema | `/redshift-erd` |
+| Offline browse without MCP | `/redshift-cache-schema` |

--- a/skills/redshift-lineage-from-stl/SKILL.md
+++ b/skills/redshift-lineage-from-stl/SKILL.md
@@ -1,22 +1,14 @@
 ---
 name: redshift-lineage-from-stl
 description: >-
-  Mine Redshift's STL_QUERY (provisioned) or SYS_QUERY_HISTORY
-  (serverless) + sqlglot SQL parsing to reconstruct ACTUAL table-to-table
-  data flow from query history — catching ad-hoc, BI-tool (Tableau /
-  Looker), and manual-fix usage that dbt manifest cannot see. Outputs
-  adjacency table + optional Mermaid graph with usage frequency, top
-  users, time range. Ships a sqlglot helper script (SQL parsing is
-  LLM-unreliable). Read-only. Use when user invokes
-  /redshift-lineage-from-stl, or says: "actual lineage", "who reads
-  this table", "real query history", "STL lineage", "ad-hoc usage of",
-  "Tableau usage of", "find consumers of", "實際 lineage", "誰在讀這
-  table", "看 query 歷史", "從 STL 查使用情況", "STL_QUERY から",
-  "実際の利用状況", "クエリ履歴から系譜", "誰が読んでいる". Do NOT
-  use for: dbt-internal lineage (use dbt-wiki / dbt docs), declared
-  FKs (use /redshift-erd), questions older than STL retention (~2-5
-  days on provisioned), permission-restricted accounts (STL needs
-  admin or specific GRANTs), real-time monitoring (this is batch).
+  Reconstruct ACTUAL table-to-table data flow from Redshift query
+  history — catches ad-hoc, BI-tool (Tableau / Looker), and manual-fix
+  usage dbt manifest cannot see. Read-only. Use when auditing who
+  reads / writes a table, or before deprecating one. Do NOT use for
+  dbt-internal lineage (use dbt manifest), declared FKs (use
+  /redshift-erd), or real-time monitoring. Triggers:
+  /redshift-lineage-from-stl / actual lineage / who reads / Tableau
+  usage / 實際 lineage / 誰在讀 / クエリ履歴.
 ---
 
 # Redshift Lineage from STL_QUERY
@@ -116,6 +108,14 @@ Footer: "Mined N queries from <since> to <now>. Found M edges across
 K tables. P parse errors. Earliest STL row: <ts> (warn if `--since`
 exceeds retention)."
 
+## Anti-patterns
+
+- NEVER parse SQL with regex — multi-statement SQL, CTEs, comments, and quoted identifiers all break naive matching. Use the bundled `sqlglot` helper script.
+- NEVER trust results past STL retention (~2-5 days provisioned) without warning — older rows silently disappear, biasing edge counts and "last seen" timestamps.
+- NEVER mix `STL_QUERY` (provisioned) and `SYS_QUERY_HISTORY` (serverless) in one report — different schemas; pick one based on `version()` detection.
+- NEVER omit the truncated-SQL warning when `LISTAGG` hits `VARCHAR(65535)` — partial parses produce phantom edges. Surface the truncation visibly.
+- NEVER hide `parse_errors` — list them verbatim so the user can audit what was missed and decide whether the result is trustworthy.
+
 ## Errors
 | Condition | Behavior |
 |---|---|
@@ -126,3 +126,11 @@ exceeds retention)."
 | `uv` not available | `_error: uv_unavailable` |
 | Zero queries in window | not error — render empty + hint widen window |
 | > 50% queries failed parse | warn loudly, proceed with what parsed |
+
+## See also
+
+| Need | Use |
+|---|---|
+| Declared (catalog) lineage — complement, not substitute | `/redshift-erd` |
+| Structure cache only (this skill mines runtime) | `/redshift-cache-schema` |
+| dbt internal model lineage | dbt manifest / dbt docs |

--- a/skills/redshift-profile/SKILL.md
+++ b/skills/redshift-profile/SKILL.md
@@ -1,19 +1,14 @@
 ---
 name: redshift-profile
 description: >-
-  Profile a Redshift column: cardinality, top-N values, null rate, min/max,
-  plus existing comment — one round, composing redshift-comment-mcp's
-  list_columns + execute_sql. Read-only. Outputs JSON (chainable into
-  /redshift-suggest-schema-yml) + a chat summary. Use when user invokes
-  /redshift-profile, or says: "profile this column", "what values does
-  X contain", "is this an enum", "show distinct values", "value
-  distribution", "cardinality of", "top values", "null rate",
-  "看欄位有哪些值", "這欄位是不是 enum", "欄位分布", "幾種值", "空值比例",
-  "列舉值", "看資料樣本", "カラムプロファイル", "値の分布", "列挙値",
-  "欠損率", "ユニーク値". Do NOT use for: full row counts (use
-  execute_sql), schema/table search (use search_columns), writing to
-  Redshift (read-only charter), free-text columns where top-100 is
-  meaningless (warn and skip).
+  Profile a Redshift column — cardinality, top-N values, null rate,
+  min/max, plus comment. Read-only. Use when about to write CREATE
+  TABLE or dbt schema.yml based on column assumptions, or to check
+  whether a column is an enum. Do NOT use for full row counts (use
+  execute_sql), schema/table search (use search_columns), or
+  free-text columns where top-100 is noise. Triggers:
+  /redshift-profile / profile column / distinct values / enum /
+  欄位分布 / カラムプロファイル / 値の分布.
 ---
 
 # Redshift Column Profile
@@ -111,6 +106,14 @@ ending with a one-line interpretation hint:
 - high → "probably ID / free text"
 - null_pct>50% → "mostly null — verify upstream"
 
+## Anti-patterns
+
+- NEVER use MCP keys `column_name` / `data_type` — MCP returns `{name, type, nullable, comment}`. Wrong shape costs a debugging cycle.
+- NEVER profile free-text or huge-cardinality columns without warning the user — top-100 of `varchar(2000)` is noise. Warn and confirm before scanning.
+- NEVER skip the `::text` cast in the top-N CTE — Redshift coerces booleans/dates inconsistently across drivers; uniform JSON shape requires explicit cast.
+- NEVER report `min` / `max` for `string` / `boolean` types — lexical extrema mislead, and `/redshift-suggest-schema-yml` would turn them into range bounds.
+- NEVER swallow `execute_sql` errors — Redshift error text is diagnostic. Surface verbatim under `_error: execute_sql_failed`.
+
 ## Errors
 | Condition | `_error` |
 |---|---|
@@ -120,3 +123,11 @@ ending with a one-line interpretation hint:
 | execute_sql failed | `execute_sql_failed: <verbatim>` |
 
 Surface execute_sql errors verbatim — Redshift errors are diagnostic.
+
+## See also
+
+| Need | Use |
+|---|---|
+| Chain a profile into a dbt yml draft | `/redshift-suggest-schema-yml` |
+| Find which column to profile | `/redshift-explore` |
+| Structure (vs values) | `/redshift-cache-schema` |

--- a/skills/redshift-setup/SKILL.md
+++ b/skills/redshift-setup/SKILL.md
@@ -1,17 +1,16 @@
 ---
 name: redshift-setup
 description: >-
-  Conversational walkthrough for configuring a Redshift connection profile
-  for the redshift-comment-mcp plugin. Default form `/redshift-setup`
-  asks host / port / user / dbname (4 questions) and stores under the
-  built-in profile name `default`; named form `/redshift-setup <name>`
-  is the multi-cluster path and additionally auto-writes the
-  pluginConfigs profile selection in ~/.claude/settings.json so the
-  user does not have to hand-edit JSON. Password collection is handed
-  off to the user's own terminal (so password never enters Claude
-  conversation history); connection is verified via test-connection.
-  Use when user invokes /redshift-setup or asks to configure / set up
-  a Redshift connection. Redshift 連線設定対話フロー。
+  Configure a Redshift connection profile for the redshift-comment-mcp
+  plugin via chat — password stored in OS keychain via dialog or
+  terminal handoff (never in chat history), connection verified.
+  Named form `/redshift-setup <name>` also writes profile selection
+  to settings.json. Use when setting up first Redshift cluster or
+  adding another. Do NOT use for password-only changes (use
+  set-password CLI), profile deletion (use delete-profile), or
+  non-interactive setup. Triggers: /redshift-setup / set up Redshift
+  / add cluster / 設定 Redshift / 新增 cluster / 接続を設定 /
+  プロファイル.
 ---
 
 # Redshift Setup
@@ -151,94 +150,51 @@ tool stdout, or in any tool result that gets added back to the
 conversation transcript. Empirically verified during dry-run:
 `osascript ... text returned of result` echoed to stdout WILL surface
 the typed value into the Bash tool's response → into the JSONL
-transcript → durable on disk. Choose the right path below to avoid
-that leak.
+transcript → durable on disk. The reference files below contain the
+exact recipes that avoid that leak — follow them verbatim.
 
-**Three paths**, picked by OS detection at runtime:
+#### Step 4.1 — Detect OS
 
-#### Path 4a — macOS desktop: native password dialog (preferred)
-
-Run this Bash one-liner. The dialog appears outside the Claude UI;
-the password lives only in a shell variable inside the subshell
-(never echoed); only `✓ Password stored` reaches Bash stdout.
+Run this decision tree once at runtime to pick exactly ONE path:
 
 ```bash
-PW=$(osascript \
-       -e 'tell application "System Events" to display dialog "Redshift password for profile <NAME>:" default answer "" with hidden answer with title "Redshift MCP Setup" buttons {"Cancel", "Save"} default button "Save"' \
-       -e 'text returned of result' 2>/dev/null) \
-  || { echo "Cancelled by user" >&2; exit 1; }
-uv run --project "$PLUGIN_ROOT" python -c "
-import sys, keyring
-keyring.set_password('redshift-comment-mcp', '<NAME>', sys.stdin.read().rstrip('\n'))
-" <<< "$PW"
-unset PW
-echo "✓ Password stored in OS keychain"
-```
-
-Replace `<NAME>` with the profile name from Step 2. Substitute
-`$PLUGIN_ROOT` with the path resolved in Step 1 (or expand it in
-the same shell session if you exported it).
-
-DO NOT add `set -x` / verbose flags — they would echo the expanded
-`$PW` to stderr.
-
-#### Path 4b — Linux desktop with `zenity` available
-
-```bash
-if command -v zenity >/dev/null 2>&1; then
-  PW=$(zenity --password --title="Redshift MCP Setup" \
-              --text="Redshift password for profile <NAME>:" 2>/dev/null) \
-    || { echo "Cancelled by user" >&2; exit 1; }
-  uv run --project "$PLUGIN_ROOT" python -c "
-import sys, keyring
-keyring.set_password('redshift-comment-mcp', '<NAME>', sys.stdin.read().rstrip('\n'))
-" <<< "$PW"
-  unset PW
-  echo "✓ Password stored in OS keychain"
-fi
-```
-
-#### Path 4c — fallback (headless server, no GUI, Cowork uncertainty, Windows): user-terminal handoff
-
-If neither dialog path is available, fall back to the
-user-terminal-handoff pattern (per
-`domain-teams:skill-team / standards/user-terminal-handoff.md`).
-Print this block verbatim to the user — substitute `<NAME>` with the
-profile name:
-
-```
-請在你自己的 terminal（不是 Claude 對話）跑這條指令來設定密碼：
-
-    uvx --from "git+https://github.com/kouko/redshift-comment-mcp.git" \
-        redshift-comment-mcp set-password --profile <NAME>
-
-它會用 getpass 隱藏輸入（你打的字不會顯示），密碼會存進 OS keychain。
-完成後回我「done」。
-```
-
-(If user's chat language is English / 日本語, translate prose
-accordingly. Keep the command verbatim.)
-
-Then **stop and wait** for the user's "done" reply. Do NOT
-background-poll. Do NOT call `set-password` via Bash — that would
-defeat the entire point.
-
-#### Decision tree
-
-```bash
-# At runtime, decide which path to take:
 if [[ "$OSTYPE" == darwin* ]]; then
-    # → Path 4a (osascript)
+    PASSWORD_PATH=4a  # macOS native dialog
 elif command -v zenity >/dev/null 2>&1; then
-    # → Path 4b (zenity)
+    PASSWORD_PATH=4b  # Linux zenity dialog
 else
-    # → Path 4c (terminal handoff)
+    PASSWORD_PATH=4c  # terminal handoff
 fi
 ```
 
-Always announce the chosen path to the user in chat ("我會跳一個系統
-對話框收密碼" / "I'll show a system dialog for the password" / etc.)
-so they know to look for the OS dialog and don't switch contexts.
+Announce the chosen path to the user in chat ("我會跳一個系統對話框收
+密碼" / "I'll show a system dialog for the password" / "我會請你在自己
+的 terminal 設密碼") so they know where to look.
+
+#### Step 4.2 — Load the matching recipe and execute it
+
+Each path has its own complete bash recipe + caveats in a dedicated
+reference file. The recipes are not interchangeable: each one's
+caveats are tuned to that OS's specific transcript-leak vectors.
+
+- **Path 4a (macOS)** — **MANDATORY: read entire file
+  [`references/password-macos.md`](references/password-macos.md)**
+  before executing. Run the recipe in that file verbatim.
+- **Path 4b (Linux + zenity)** — **MANDATORY: read entire file
+  [`references/password-zenity.md`](references/password-zenity.md)**
+  before executing.
+- **Path 4c (terminal handoff)** — **MANDATORY: read entire file
+  [`references/password-terminal-handoff.md`](references/password-terminal-handoff.md)**
+  before executing.
+
+**Do NOT load the other two reference files** — each contains the
+full bash recipe for one path; loading more than one wastes context
+and can confuse which recipe to run. If the chosen path errors out
+mid-execution, the reference file for that path documents the
+fallback (typically Path 4c).
+
+After the chosen path emits `✓ Password stored in OS keychain` (or
+the user replies "done" on Path 4c), continue to Step 5.
 
 ### Step 5 — Verify
 

--- a/skills/redshift-setup/references/password-macos.md
+++ b/skills/redshift-setup/references/password-macos.md
@@ -1,0 +1,50 @@
+# Password Collection — macOS Path 4a
+
+Native `osascript` password dialog. The dialog appears outside the
+Claude UI; the password lives only in a shell variable inside the
+subshell (never echoed); only `✓ Password stored` reaches Bash stdout.
+
+```bash
+PW=$(osascript \
+       -e 'tell application "System Events" to display dialog "Redshift password for profile <NAME>:" default answer "" with hidden answer with title "Redshift MCP Setup" buttons {"Cancel", "Save"} default button "Save"' \
+       -e 'text returned of result' 2>/dev/null) \
+  || { echo "Cancelled by user" >&2; exit 1; }
+uv run --project "$PLUGIN_ROOT" python -c "
+import sys, keyring
+keyring.set_password('redshift-comment-mcp', '<NAME>', sys.stdin.read().rstrip('\n'))
+" <<< "$PW"
+unset PW
+echo "✓ Password stored in OS keychain"
+```
+
+Replace `<NAME>` with the profile name from Step 2. Substitute
+`$PLUGIN_ROOT` with the path resolved in Step 1 (or expand it in the
+same shell session if you exported it).
+
+## Critical safety rules
+
+- **DO NOT add `set -x` / verbose flags** — they would echo the
+  expanded `$PW` to stderr.
+- **DO NOT log `$PW`** for debugging — anything in Bash stdout / stderr
+  reaches the JSONL transcript on disk.
+- **DO NOT add `echo "$PW"` even temporarily** — same reason.
+- **DO NOT remove the `2>/dev/null`** on the `osascript` call — without
+  it, dialog cancellation prints a Cocoa error containing user-visible
+  state to stderr.
+
+## Why this path is preferred on macOS
+
+`osascript` ships with the OS — no install step. The "with hidden
+answer" flag masks the typed value as dots, and the dialog runs in a
+separate process so its return value never traverses the Claude
+agent's conversation pipeline.
+
+## When to fall back
+
+If `osascript` exits non-zero with a permission error (rare; happens
+when accessibility / automation prompts are denied), surface the error
+to the user and offer to switch to Path 4c (terminal handoff). Do NOT
+prompt for the password directly in chat — there is no chat fallback.
+
+After the `✓ Password stored` line appears, return to SKILL.md
+**Step 5** (verify connection).

--- a/skills/redshift-setup/references/password-terminal-handoff.md
+++ b/skills/redshift-setup/references/password-terminal-handoff.md
@@ -1,0 +1,56 @@
+# Password Collection — Terminal Handoff Path 4c
+
+Use this path when no GUI dialog is available — headless servers,
+Cowork uncertainty, Windows without a wrapped GUI, or as the fallback
+when Path 4a / 4b errors out. This is the canonical "user-terminal
+handoff" pattern from `domain-teams:skill-team / standards/user-terminal-handoff.md`
+(kobo-auth Flow A in monkey-skills/tsundoku is the reference
+implementation).
+
+## Print this block verbatim to the user
+
+Substitute `<NAME>` with the profile name; translate the prose to the
+user's chat language (zh-TW / zh-CN / ja / en) but **keep the command
+verbatim**:
+
+```
+請在你自己的 terminal（不是 Claude 對話）跑這條指令來設定密碼：
+
+    uvx --from "git+https://github.com/kouko/redshift-comment-mcp.git" \
+        redshift-comment-mcp set-password --profile <NAME>
+
+它會用 getpass 隱藏輸入（你打的字不會顯示），密碼會存進 OS keychain。
+完成後回我「done」。
+```
+
+Then **stop and wait** for the user's "done" reply.
+
+## Critical safety rules
+
+- **DO NOT background-poll the keychain** to detect when the password
+  lands — adds I/O noise and can race with the user's typing in the
+  external terminal.
+- **DO NOT call `set-password` via Bash** — that would defeat the
+  entire point of this path (the password would enter Claude's
+  transcript via the Bash tool's stdin / stdout / stderr).
+- **DO NOT prompt the user for the password in chat as a "fallback"** —
+  there is no chat fallback. The keychain entry is the only acceptable
+  destination. If the user types a password in chat by mistake,
+  treat it as compromised: ask them to rotate it on the DB side and
+  rerun this path.
+- **DO NOT translate or modify the `uvx` command line** — even adding
+  `\` line continuations or quoting changes can break paste-ability
+  across terminals.
+
+## Why this path exists
+
+Some environments (Windows, headless boxes, locked-down corporate
+machines) have no GUI dialog Claude can drive. The handoff hands
+control of password entry to a process Claude cannot observe — the
+user's own terminal, where `getpass` masks input below the OS layer
+that Claude has access to. The "done" reply is the synchronization
+signal that the keychain entry is in place.
+
+After the user's "done" reply, return to SKILL.md **Step 5** (verify
+connection). Do not assume the password landed — Step 5's
+`test-connection` is the only reliable check.

--- a/skills/redshift-setup/references/password-zenity.md
+++ b/skills/redshift-setup/references/password-zenity.md
@@ -1,0 +1,42 @@
+# Password Collection — Linux Path 4b
+
+`zenity --password` dialog. Same security model as macOS path: the
+password lives only in a subshell variable, never reaches Bash stdout.
+
+```bash
+if command -v zenity >/dev/null 2>&1; then
+  PW=$(zenity --password --title="Redshift MCP Setup" \
+              --text="Redshift password for profile <NAME>:" 2>/dev/null) \
+    || { echo "Cancelled by user" >&2; exit 1; }
+  uv run --project "$PLUGIN_ROOT" python -c "
+import sys, keyring
+keyring.set_password('redshift-comment-mcp', '<NAME>', sys.stdin.read().rstrip('\n'))
+" <<< "$PW"
+  unset PW
+  echo "✓ Password stored in OS keychain"
+fi
+```
+
+Replace `<NAME>` with the profile name from Step 2. Substitute
+`$PLUGIN_ROOT` with the path resolved in Step 1.
+
+## Critical safety rules
+
+- **DO NOT add `set -x` / verbose flags** — they would echo the expanded `$PW` to stderr.
+- **DO NOT log `$PW`** for debugging.
+- **DO NOT add `echo "$PW"` even temporarily** — Bash stdout / stderr
+  reaches the JSONL transcript on disk.
+- **DO NOT remove the `2>/dev/null`** on the `zenity` call — without
+  it, GTK warnings can leak environment hints (display name,
+  user-installed themes) into the transcript.
+
+## When to fall back
+
+`zenity` is not installed by default on all distros. If the
+`command -v zenity` check fails, **immediately switch** to Path 4c
+(terminal handoff) — do NOT try `kdialog` as a substitute (KDE's
+dialog exposes the password value in `ps` output on some distros).
+There is no chat fallback.
+
+After the `✓ Password stored` line appears, return to SKILL.md
+**Step 5** (verify connection).

--- a/skills/redshift-suggest-schema-yml/SKILL.md
+++ b/skills/redshift-suggest-schema-yml/SKILL.md
@@ -1,20 +1,14 @@
 ---
 name: redshift-suggest-schema-yml
 description: >-
-  Draft a dbt schema.yml v2 `models:` block for a Redshift table:
-  description from existing comments, data_type, and conservative test
-  suggestions (not_null / unique / accepted_values) inferred from a
-  profile run. Composes /redshift-profile per column. Outputs paste-ready
-  YAML + per-column rationale; never writes to disk. Use when user
-  invokes /redshift-suggest-schema-yml, or says: "draft schema.yml",
-  "generate dbt yml", "suggest dbt tests", "schema.yml for X", "dbt
-  model spec", "accepted_values for", "推薦 dbt 測試", "幫我寫 schema.yml",
-  "產生 dbt yml", "schema.yml 草稿", "dbt 欄位測試建議", "dbt スキーマ
-  提案", "schema.yml の下書き", "受入値テスト". Do NOT use for: writing
-  YAML to disk (chat only — user pastes), merging into existing
-  schema.yml (drafts only), foreign-key relationships (no FK info from
-  MCP), profiling alone (use /redshift-profile), or sources: blocks
-  (out of scope for this skill — only models: blocks supported).
+  Draft a dbt schema.yml v2 `models:` block for a Redshift table with
+  conservative test suggestions (not_null / unique / accepted_values)
+  inferred from a profile run. Read-only. Use when about to write
+  schema.yml from scratch or backfill tests on an existing table. Do
+  NOT use for writing YAML to disk (chat-only by charter), profiling
+  alone (use /redshift-profile), or sources: blocks (models: only).
+  Triggers: /redshift-suggest-schema-yml / draft schema.yml / dbt yml
+  / dbt tests / dbt スキーマ提案 / 受入値テスト.
 ---
 
 # Redshift → dbt schema.yml Draft
@@ -117,6 +111,14 @@ Plus rationale table (chat):
 ```
 End with: "Drafted N columns — M with full tests, K TODO desc, P unsupported. Review before merging."
 
+## Anti-patterns
+
+- NEVER suggest a test current data violates — `not_null` only when `null_count == 0`; use commented-out form for `0 < null_pct < 1%`. False-positive tests erode trust in the whole `schema.yml`.
+- NEVER write to disk — chat-only by charter. The user pastes; in-place merging into existing `schema.yml` is out of scope.
+- NEVER suggest `accepted_values` for high-cardinality strings — `cardinality_class` must be `"low"` AND `distinct ≤ 20`. Otherwise the test churns on every new row.
+- NEVER skip the per-column rationale table — without it the user can't audit why each test landed and which to drop.
+- NEVER infer `relationships:` tests — no FK info from MCP; that's `/redshift-erd` territory.
+
 ## Errors
 | Condition | `_error` |
 |---|---|
@@ -126,3 +128,11 @@ End with: "Drafted N columns — M with full tests, K TODO desc, P unsupported. 
 | Every column failed | `profile_failed_for_all_columns` |
 
 Per-column failures degrade gracefully — partial output beats no output.
+
+## See also
+
+| Need | Use |
+|---|---|
+| Profile a column to feed this skill | `/redshift-profile` |
+| Relationship inference (deliberately excluded here) | `/redshift-erd` |
+| Find tables to draft yml for | `/redshift-explore` |


### PR DESCRIPTION
## Summary

Audit via \`dev-workflow:skill-judge\` + iterating with \`dev-workflow:skill-creator-advance\`'s \`description-design.md\` reference surfaced two systemic gaps across this plugin's 7 skills:

1. **Description bloat** — every description had workflow leak in the WHAT clause, full-sentence multi-language triggers, and 700-1000+ chars (vs description-design.md's empirical median ~107 chars from 14 superpowers skills, and the worked git-memory case study at 287 chars).
2. **Missing anti-patterns + sister-skill routing** — 6 of 7 skills lacked \`## Anti-patterns\` and \`## See also\` sections; D3 (anti-pattern quality) and skill-judge's "navigation between sibling skills" both scored weak.

This PR fixes both, plus does a structural redesign of \`redshift-setup\` to demonstrate progressive disclosure.

## What changed

### 6 skills — incremental fixes
**\`redshift-cache-schema\`, \`redshift-erd\`, \`redshift-explore\`, \`redshift-lineage-from-stl\`, \`redshift-profile\`, \`redshift-suggest-schema-yml\`:**
- New \`## Anti-patterns\` section: 5 NEVER bullets each, every one carrying the WHY ("NEVER skip \`::text\` cast in top-N CTE — Redshift coerces booleans/dates inconsistently across drivers; uniform JSON shape requires explicit cast")
- New \`## See also\` section: routing tables to sister skills
- Description trimmed to 392-521 chars (was 777-1001) using the superpowers keyword-belt pattern: \`Triggers: A / B / 中 / 日.\`

### \`redshift-setup\` — Case (c) structural rewrite
- Description: 1021 → 569 chars (-44%), with multi-lang triggers + Do NOT use clauses
- Step 4 progressive disclosure: 95 inline lines for three OS-aware password paths replaced by a 50-line decision tree + MANDATORY load triggers pointing to dedicated reference files
- Each new \`references/password-{macos,zenity,terminal-handoff}.md\` carries the OS-specific safety rules — \`osascript set -x leak\`, \`kdialog ps-output leak\`, terminal-handoff sync contract
- Folder layout stays flat per Anthropic skill convention

## Numbers

| Region | Before | After | Δ |
|---|--:|--:|--:|
| 7 skill descriptions (chars) | 6,291 | 3,388 | -46% |
| \`redshift-setup\` SKILL.md lines | 408 | 371 | -9% |
| \`/redshift-setup/references/\` files | 0 | 3 | new |

~725 tokens saved per conversation across the 7 skill descriptions in the system prompt.

## Test plan

- [x] \`pytest tests/\` — 98 passed (no runtime contract changes)
- [x] \`find skills -mindepth 3 -type d\` — empty (folder structure flatness preserved per Anthropic convention)
- [x] All 7 SKILL.md frontmatter still YAML-parseable
- [ ] Dogfood for 1 week to verify skill triggering accuracy didn't regress (will follow up if any prompt undertriggers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)