### PR TITLE
chore(gitignore): add uv.lock and fix *.sqlite3 typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,8 @@ Desktop.ini
 *.pyo
 *.pyd
 *.db
-*.sqlite3uv.lock
+*.sqlite3
+uv.lock
 
 # Claude Code editor-local settings (per-user, not for repo)
 .claude/


### PR DESCRIPTION
## Summary

Two small fixes to `.gitignore`:

1. **Add `uv.lock`** — generated transiently when contributors run `uv run pytest`; project doesn't pin via uv (conda is primary), so it shouldn't be tracked.
2. **Fix pre-existing typo on line 108** — `*.sqlite3uv.lock` was a missing-newline mash-up that silently broke both intended patterns. Splitting into two lines restores both.

## Verification

```
$ git check-ignore -v uv.lock
.gitignore:109:uv.lock	uv.lock

$ git check-ignore -v test.sqlite3
.gitignore:108:*.sqlite3	test.sqlite3
```

Both patterns now match as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)