### PR TITLE
perf(redshift_tools): rewrite column metadata SQL with direct LEFT JOINs

### DIFF
--- a/src/redshift_comment_mcp/redshift_tools.py
+++ b/src/redshift_comment_mcp/redshift_tools.py
@@ -410,11 +410,9 @@ line suggesting /redshift-cache-schema --refresh.
                         c.is_nullable,
                         d.description AS column_comment
                     FROM information_schema.columns c
-                    LEFT JOIN pg_description d ON d.objoid = (
-                        SELECT oid FROM pg_class WHERE relname = c.table_name AND relnamespace = (
-                            SELECT oid FROM pg_namespace WHERE nspname = c.table_schema
-                        )
-                    ) AND d.objsubid = c.ordinal_position
+                    LEFT JOIN pg_namespace n ON n.nspname = c.table_schema
+                    LEFT JOIN pg_class cl ON cl.relname = c.table_name AND cl.relnamespace = n.oid
+                    LEFT JOIN pg_description d ON d.objoid = cl.oid AND d.objsubid = c.ordinal_position
                     WHERE c.table_schema = %s AND c.table_name = %s
                     ORDER BY c.ordinal_position;
                     """
@@ -630,11 +628,9 @@ line suggesting /redshift-cache-schema --refresh.
                 c.is_nullable,
                 COALESCE(d.description, '') AS column_comment
             FROM information_schema.columns c
-            LEFT JOIN pg_description d ON d.objoid = (
-                SELECT oid FROM pg_class WHERE relname = c.table_name AND relnamespace = (
-                    SELECT oid FROM pg_namespace WHERE nspname = c.table_schema
-                )
-            ) AND d.objsubid = c.ordinal_position
+            LEFT JOIN pg_namespace n ON n.nspname = c.table_schema
+            LEFT JOIN pg_class cl ON cl.relname = c.table_name AND cl.relnamespace = n.oid
+            LEFT JOIN pg_description d ON d.objoid = cl.oid AND d.objsubid = c.ordinal_position
             WHERE c.table_schema = %s AND c.table_name = %s
             """
 
@@ -751,11 +747,9 @@ line suggesting /redshift-cache-schema --refresh.
             sql = """
             SELECT c.data_type, d.description AS column_comment
             FROM information_schema.columns c
-            LEFT JOIN pg_description d ON d.objoid = (
-                SELECT oid FROM pg_class WHERE relname = c.table_name AND relnamespace = (
-                    SELECT oid FROM pg_namespace WHERE nspname = c.table_schema
-                )
-            ) AND d.objsubid = c.ordinal_position
+            LEFT JOIN pg_namespace n ON n.nspname = c.table_schema
+            LEFT JOIN pg_class cl ON cl.relname = c.table_name AND cl.relnamespace = n.oid
+            LEFT JOIN pg_description d ON d.objoid = cl.oid AND d.objsubid = c.ordinal_position
             WHERE c.table_schema = %s AND c.table_name = %s AND c.column_name = %s;
             """
             with self.config.get_connection() as conn:
@@ -787,11 +781,9 @@ line suggesting /redshift-cache-schema --refresh.
                 c.is_nullable,
                 d.description AS column_comment
             FROM information_schema.columns c
-            LEFT JOIN pg_description d ON d.objoid = (
-                SELECT oid FROM pg_class WHERE relname = c.table_name AND relnamespace = (
-                    SELECT oid FROM pg_namespace WHERE nspname = c.table_schema
-                )
-            ) AND d.objsubid = c.ordinal_position
+            LEFT JOIN pg_namespace n ON n.nspname = c.table_schema
+            LEFT JOIN pg_class cl ON cl.relname = c.table_name AND cl.relnamespace = n.oid
+            LEFT JOIN pg_description d ON d.objoid = cl.oid AND d.objsubid = c.ordinal_position
             WHERE c.table_schema = %s AND c.table_name = %s
             ORDER BY c.ordinal_position;
             """


### PR DESCRIPTION
## Summary

Replace the two-level correlated subquery against `pg_class` + `pg_namespace` in 4 column-metadata SQLs with three sequential `LEFT JOIN`s from `information_schema.columns`:

- `list_columns(include_comments=True)`
- `search_columns`
- `get_column_comment`
- `get_all_column_comments`

The new shape is plan-stable (does not rely on Redshift auto-unnesting) and unblocks future schema-wide tooling (`search_columns_in_schema`) at viable latency.

## Live cluster benchmarks

Verified on a production Redshift cluster, 5 schemas / 26K columns total. Result sets are **identical** between OLD and NEW forms.

| Schema | Cols | OLD | NEW | Speedup |
|---|---|---|---|---|
| A (dev) | 12,120 | 5,103 ms | 1,552 ms | **3.3x** |
| B (prod) | 11,669 | 2,686 ms | 2,066 ms | 1.3x |
| C (vendor ingest) | 709 | 587 ms | 368 ms | 1.6x |
| D (marts) | 377 | 458 ms | 304 ms | 1.5x |
| E (vendor ingest) | 1,051 | 345 ms | 495 ms | 0.7x (noise) |

Single-table queries (14-161 cols) saw no measurable difference either way — Redshift's optimizer already auto-unnests correlated subqueries at small N. The win materializes at 10K+ column scale.

## Test plan

- [x] All 221 existing unit tests pass
- [x] Live cluster correctness check: 5 schemas × 26K columns, OLD/NEW result sets sort-and-compare equal
- [x] Live cluster latency check: see table above
- [ ] Reviewer: spot-check the 4 rewritten SQL blocks for readability

## Notes

- No API surface change; all callers see identical behavior.
- Verification scripts are local-only and not committed; reusable for future SQL refactors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)