### PR TITLE
feat(redshift_tools): add comment cap and scale_hint for safer multi-item responses

### DIFF
--- a/src/redshift_comment_mcp/redshift_tools.py
+++ b/src/redshift_comment_mcp/redshift_tools.py
@@ -10,6 +10,16 @@ logger = logging.getLogger(__name__)
 # 分頁設定
 DEFAULT_MAX_ITEMS = 50  # 預設最大回傳筆數（超過時自動截斷）
 
+# Comment 大小防護
+# 經 production cluster 實測（2026-05-08, n=8534）：column comment p100=471，
+# table comment p90=919 / p95=1517 / p100=3680。1000 字元截斷 9% 的 table
+# 長尾，column comment 完全不受影響。單筆 getter（get_table_comment 等）不
+# 套用，使用者要全文時走那條路。
+MAX_COMMENT_LEN = 1000
+
+# scale_hint 觸發門檻：list_tables 回應 total_count 超過此值時附上分頁成本提示
+SCALE_HINT_THRESHOLD = 100
+
 
 # ===== SQL 安全驗證 =====
 
@@ -195,6 +205,42 @@ def paginate_results(items: list, limit: Optional[int], offset: int, default_max
     }
 
 
+def apply_comment_cap(items: list, key: str, max_len: int = MAX_COMMENT_LEN) -> int:
+    """In-place truncate the comment field at ``key`` for each item in ``items``;
+    returns the count of items that were truncated.
+
+    Items whose comment is shorter than or equal to ``max_len`` are left
+    untouched. Truncated comments get an ellipsis appended so the caller
+    can detect truncation visually as well as via the returned count.
+    """
+    count = 0
+    for item in items:
+        original = item.get(key)
+        if isinstance(original, str) and len(original) > max_len:
+            item[key] = original[:max_len] + "…"
+            count += 1
+    return count
+
+
+def build_scale_hint(total_count: int, page_size: int = DEFAULT_MAX_ITEMS) -> Optional[str]:
+    """Return a one-line scale hint when total_count would force painful
+    pagination, or None when the result is small enough to enumerate fully.
+
+    The threshold (SCALE_HINT_THRESHOLD) is intentionally above one page
+    so the hint only fires when full enumeration genuinely costs ≥3 round
+    trips. Message includes the actual page count so the LLM can weigh
+    cost objectively rather than relying on a magic threshold.
+    """
+    if total_count <= SCALE_HINT_THRESHOLD:
+        return None
+    pages = (total_count + page_size - 1) // page_size
+    return (
+        f"This schema has {total_count} tables. "
+        f"Full enumeration would need {pages} paginated tool calls. "
+        f"Consider search_tables(keywords) or /redshift-cache-schema for goal-oriented queries."
+    )
+
+
 def calculate_hit_count(name: str, comment: str, keywords: list) -> int:
     """
     計算關鍵字在 name 和 comment 中的命中次數。
@@ -227,6 +273,16 @@ SQL; trust the comment over the name when they disagree.
 PAGINATION: list_*, search_*, and get_all_column_comments cap at 50
 items per response. Check `has_more`; if true, refetch with `offset`
 until exhausted before drawing conclusions.
+
+COMMENT TRUNCATION: Multi-item responses cap each comment at 1000
+chars. Look for `comment_truncated_count` in the response; if present,
+some comments were cut. Call get_table_comment / get_column_comment
+on the specific item for full text. Single-item getters never truncate.
+
+SCALE GUIDANCE: list_tables emits `scale_hint` when total_count > 100.
+For schemas at that size, paginating list_tables to completion is
+expensive — prefer search_tables(keywords) for goal-oriented queries
+or /redshift-cache-schema for bulk analysis.
 
 OPTIMIZATION: list_* tools accept include_comments / include_parent_comments
 flags to fold get_*_comment calls into the same response.
@@ -358,6 +414,11 @@ line suggesting /redshift-cache-schema --refresh.
             # 分頁處理
             page = paginate_results(tables, limit, offset, DEFAULT_MAX_ITEMS)
 
+            # Comment 字元截斷（多筆回應防護；只對實際回傳的項目套用）
+            truncated_count = 0
+            if include_comments:
+                truncated_count = apply_comment_cap(page["items"], "comment")
+
             result = {
                 "schema_name": schema_name,
                 "total_count": page["total_count"],
@@ -373,6 +434,17 @@ line suggesting /redshift-cache-schema --refresh.
 
             if page["auto_truncated"]:
                 result["pagination_hint"] = f"Results auto-truncated to {DEFAULT_MAX_ITEMS}. Use limit/offset to retrieve more."
+
+            if truncated_count > 0:
+                result["comment_truncated_count"] = truncated_count
+                result["comment_truncated_hint"] = (
+                    f"{truncated_count} of {page['returned_count']} table comments were truncated "
+                    f"at {MAX_COMMENT_LEN} chars. Use get_table_comment(schema, table) for full text."
+                )
+
+            scale_hint = build_scale_hint(page["total_count"])
+            if scale_hint:
+                result["scale_hint"] = scale_hint
 
             return result
 
@@ -438,6 +510,11 @@ line suggesting /redshift-cache-schema --refresh.
             # 分頁處理
             page = paginate_results(columns, limit, offset, DEFAULT_MAX_ITEMS)
 
+            # Comment 字元截斷（多筆回應防護；只對實際回傳的項目套用）
+            truncated_count = 0
+            if include_comments:
+                truncated_count = apply_comment_cap(page["items"], "comment")
+
             result = {
                 "schema_name": schema_name,
                 "table_name": table_name,
@@ -454,6 +531,13 @@ line suggesting /redshift-cache-schema --refresh.
 
             if page["auto_truncated"]:
                 result["pagination_hint"] = f"Results auto-truncated to {DEFAULT_MAX_ITEMS}. Use limit/offset to retrieve more."
+
+            if truncated_count > 0:
+                result["comment_truncated_count"] = truncated_count
+                result["comment_truncated_hint"] = (
+                    f"{truncated_count} of {page['returned_count']} column comments were truncated "
+                    f"at {MAX_COMMENT_LEN} chars. Use get_column_comment(schema, table, col) for full text."
+                )
 
             return result
 
@@ -590,6 +674,9 @@ line suggesting /redshift-cache-schema --refresh.
             # 分頁處理
             page = paginate_results(tables, limit, offset, DEFAULT_MAX_ITEMS)
 
+            # Comment 字元截斷（search 永遠帶 comment，無 include_comments flag）
+            truncated_count = apply_comment_cap(page["items"], "table_comment")
+
             result = {
                 "keywords": keyword_list,
                 "schema_filter": schema_name,
@@ -603,6 +690,13 @@ line suggesting /redshift-cache-schema --refresh.
 
             if page["auto_truncated"]:
                 result["pagination_hint"] = f"Results auto-truncated to {DEFAULT_MAX_ITEMS}. Use limit/offset to retrieve more."
+
+            if truncated_count > 0:
+                result["comment_truncated_count"] = truncated_count
+                result["comment_truncated_hint"] = (
+                    f"{truncated_count} of {page['returned_count']} table comments were truncated "
+                    f"at {MAX_COMMENT_LEN} chars. Use get_table_comment(schema, table) for full text."
+                )
 
             return result
 
@@ -669,6 +763,9 @@ line suggesting /redshift-cache-schema --refresh.
             # 分頁處理
             page = paginate_results(columns, limit, offset, DEFAULT_MAX_ITEMS)
 
+            # Comment 字元截斷（search 永遠帶 comment，無 include_comments flag）
+            truncated_count = apply_comment_cap(page["items"], "column_comment")
+
             result = {
                 "keywords": keyword_list,
                 "schema_name": schema_name,
@@ -683,6 +780,13 @@ line suggesting /redshift-cache-schema --refresh.
 
             if page["auto_truncated"]:
                 result["pagination_hint"] = f"Results auto-truncated to {DEFAULT_MAX_ITEMS}. Use limit/offset to retrieve more."
+
+            if truncated_count > 0:
+                result["comment_truncated_count"] = truncated_count
+                result["comment_truncated_hint"] = (
+                    f"{truncated_count} of {page['returned_count']} column comments were truncated "
+                    f"at {MAX_COMMENT_LEN} chars. Use get_column_comment(schema, table, col) for full text."
+                )
 
             return result
 
@@ -795,6 +899,9 @@ line suggesting /redshift-cache-schema --refresh.
             # 分頁處理
             page = paginate_results(records, limit, offset, DEFAULT_MAX_ITEMS)
 
+            # Comment 字元截斷（多筆回應防護）
+            truncated_count = apply_comment_cap(page["items"], "column_comment")
+
             result = {
                 "schema_name": schema_name,
                 "table_name": table_name,
@@ -807,6 +914,13 @@ line suggesting /redshift-cache-schema --refresh.
 
             if page["auto_truncated"]:
                 result["pagination_hint"] = f"Results auto-truncated to {DEFAULT_MAX_ITEMS}. Use limit/offset to retrieve more."
+
+            if truncated_count > 0:
+                result["comment_truncated_count"] = truncated_count
+                result["comment_truncated_hint"] = (
+                    f"{truncated_count} of {page['returned_count']} column comments were truncated "
+                    f"at {MAX_COMMENT_LEN} chars. Use get_column_comment(schema, table, col) for full text."
+                )
 
             return result
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5,7 +5,11 @@ from contextlib import contextmanager
 from redshift_comment_mcp.redshift_tools import (
     RedshiftTools,
     paginate_results,
+    apply_comment_cap,
+    build_scale_hint,
     DEFAULT_MAX_ITEMS,
+    MAX_COMMENT_LEN,
+    SCALE_HINT_THRESHOLD,
     validate_read_only_sql,
 )
 from redshift_comment_mcp.connection import RedshiftConnectionConfig
@@ -975,3 +979,188 @@ class TestErrorHandling:
 
         with pytest.raises(ValueError, match="Invalid schema or table name"):
             get_column_comment(schema_name='valid', table_name='also-invalid', column_name='col')
+
+
+# ========== Comment cap & scale hint helper tests ==========
+
+class TestCommentCapHelper:
+    """apply_comment_cap unit tests"""
+
+    def test_short_comment_untouched(self):
+        items = [{"comment": "short"}]
+        n = apply_comment_cap(items, "comment", max_len=10)
+        assert n == 0
+        assert items[0]["comment"] == "short"
+
+    def test_long_comment_truncated_with_ellipsis(self):
+        items = [{"comment": "x" * 100}]
+        n = apply_comment_cap(items, "comment", max_len=10)
+        assert n == 1
+        assert items[0]["comment"] == "x" * 10 + "…"
+
+    def test_mixed_items_count_only_truncated(self):
+        items = [
+            {"comment": "short"},
+            {"comment": "x" * 50},
+            {"comment": "y" * 5},
+        ]
+        n = apply_comment_cap(items, "comment", max_len=10)
+        assert n == 1
+        assert items[0]["comment"] == "short"
+        assert items[1]["comment"].endswith("…")
+        assert items[2]["comment"] == "y" * 5
+
+    def test_non_string_comment_skipped(self):
+        items = [{"comment": None}, {"comment": 123}, {}]
+        n = apply_comment_cap(items, "comment", max_len=10)
+        assert n == 0  # None / int / missing key all skipped silently
+
+    def test_default_max_len_is_module_constant(self):
+        items = [{"comment": "x" * (MAX_COMMENT_LEN + 5)}]
+        n = apply_comment_cap(items, "comment")  # no explicit max_len
+        assert n == 1
+        # cap + 1 because we append the ellipsis after slicing to MAX_COMMENT_LEN
+        assert len(items[0]["comment"]) == MAX_COMMENT_LEN + 1
+
+
+class TestScaleHintHelper:
+    """build_scale_hint unit tests"""
+
+    def test_below_threshold_returns_none(self):
+        assert build_scale_hint(SCALE_HINT_THRESHOLD) is None
+        assert build_scale_hint(SCALE_HINT_THRESHOLD - 1) is None
+        assert build_scale_hint(0) is None
+
+    def test_above_threshold_returns_message_with_count(self):
+        msg = build_scale_hint(800)
+        assert msg is not None
+        assert "800" in msg
+        # 800 / 50 page_size = 16 paginated calls
+        assert "16" in msg
+        assert "search_tables" in msg
+        assert "redshift-cache-schema" in msg
+
+    def test_just_above_threshold(self):
+        msg = build_scale_hint(SCALE_HINT_THRESHOLD + 1)
+        assert msg is not None
+        # (101 + 49) // 50 = 3 pages
+        assert "3" in msg
+
+    def test_custom_page_size(self):
+        msg = build_scale_hint(200, page_size=25)
+        assert msg is not None
+        # 200 / 25 = 8 pages
+        assert "8" in msg
+
+
+class TestListTablesIntegrationWithCapAndHint:
+    """End-to-end behavior: list_tables emits scale_hint and truncates comments."""
+
+    @patch('awswrangler.redshift.read_sql_query')
+    def test_scale_hint_emitted_when_total_above_threshold(self, mock_read_sql, mock_config):
+        config, _ = mock_config
+        # Schema lookup (parent comment) + tables list. Many tables (above threshold).
+        n_tables = SCALE_HINT_THRESHOLD + 50  # 150 tables
+        schema_df = pd.DataFrame({'schema_comment': ['big schema']})
+        tables_df = pd.DataFrame({
+            'table_name': [f't{i}' for i in range(n_tables)],
+            'table_type': ['BASE TABLE'] * n_tables,
+        })
+        mock_read_sql.side_effect = [schema_df, tables_df]
+
+        tools = RedshiftTools(config)
+        list_tables = _get_tool_fn(tools, 'list_tables')
+        result = list_tables(schema_name='big')
+
+        assert result["total_count"] == n_tables
+        assert "scale_hint" in result
+        assert str(n_tables) in result["scale_hint"]
+        assert "search_tables" in result["scale_hint"]
+
+    @patch('awswrangler.redshift.read_sql_query')
+    def test_scale_hint_absent_when_total_below_threshold(self, mock_read_sql, mock_config):
+        config, _ = mock_config
+        schema_df = pd.DataFrame({'schema_comment': ['small schema']})
+        tables_df = pd.DataFrame({
+            'table_name': ['t1', 't2', 't3'],
+            'table_type': ['BASE TABLE'] * 3,
+        })
+        mock_read_sql.side_effect = [schema_df, tables_df]
+
+        tools = RedshiftTools(config)
+        list_tables = _get_tool_fn(tools, 'list_tables')
+        result = list_tables(schema_name='small')
+
+        assert "scale_hint" not in result
+
+    @patch('awswrangler.redshift.read_sql_query')
+    def test_table_comment_truncated_when_too_long(self, mock_read_sql, mock_config):
+        config, _ = mock_config
+        long_comment = "L" * (MAX_COMMENT_LEN + 500)
+        schema_df = pd.DataFrame({'schema_comment': ['s']})
+        tables_df = pd.DataFrame({
+            'table_name': ['big_table'],
+            'table_type': ['BASE TABLE'],
+            'table_comment': [long_comment],
+        })
+        mock_read_sql.side_effect = [schema_df, tables_df]
+
+        tools = RedshiftTools(config)
+        list_tables = _get_tool_fn(tools, 'list_tables')
+        result = list_tables(schema_name='s', include_comments=True)
+
+        assert result["comment_truncated_count"] == 1
+        assert "comment_truncated_hint" in result
+        assert result["tables"][0]["comment"].endswith("…")
+        assert len(result["tables"][0]["comment"]) == MAX_COMMENT_LEN + 1
+
+    @patch('awswrangler.redshift.read_sql_query')
+    def test_short_table_comment_not_flagged(self, mock_read_sql, mock_config):
+        config, _ = mock_config
+        schema_df = pd.DataFrame({'schema_comment': ['s']})
+        tables_df = pd.DataFrame({
+            'table_name': ['t'],
+            'table_type': ['BASE TABLE'],
+            'table_comment': ['short comment'],
+        })
+        mock_read_sql.side_effect = [schema_df, tables_df]
+
+        tools = RedshiftTools(config)
+        list_tables = _get_tool_fn(tools, 'list_tables')
+        result = list_tables(schema_name='s', include_comments=True)
+
+        assert "comment_truncated_count" not in result
+        assert "comment_truncated_hint" not in result
+
+
+class TestSingleGetterDoesNotTruncate:
+    """get_table_comment / get_column_comment are the full-text escape hatch."""
+
+    @patch('awswrangler.redshift.read_sql_query')
+    def test_get_table_comment_returns_full_long_text(self, mock_read_sql, mock_config):
+        config, _ = mock_config
+        long_comment = "Z" * (MAX_COMMENT_LEN + 1000)
+        mock_df = pd.DataFrame({'table_comment': [long_comment]})
+        mock_read_sql.return_value = mock_df
+
+        tools = RedshiftTools(config)
+        get_table_comment = _get_tool_fn(tools, 'get_table_comment')
+        result = get_table_comment(schema_name='s', table_name='t')
+
+        # Full text returned, no truncation, no marker
+        assert result["comment"] == long_comment
+        assert "…" not in result["comment"]
+
+    @patch('awswrangler.redshift.read_sql_query')
+    def test_get_column_comment_returns_full_long_text(self, mock_read_sql, mock_config):
+        config, _ = mock_config
+        long_comment = "C" * (MAX_COMMENT_LEN + 1000)
+        mock_df = pd.DataFrame({'data_type': ['varchar'], 'column_comment': [long_comment]})
+        mock_read_sql.return_value = mock_df
+
+        tools = RedshiftTools(config)
+        get_column_comment = _get_tool_fn(tools, 'get_column_comment')
+        result = get_column_comment(schema_name='s', table_name='t', column_name='c')
+
+        assert result["comment"] == long_comment
+        assert "…" not in result["comment"]


### PR DESCRIPTION
## Summary

Add two defense-in-depth mechanisms for `list_*` / `search_*` / `get_all_column_comments`:

### 1. `MAX_COMMENT_LEN = 1000` — single-comment cap

Each comment in a multi-item response is truncated to 1000 chars (with ellipsis marker) to bound payload size in the long tail.

- Truncated responses include `comment_truncated_count` + `comment_truncated_hint` pointing at `get_table_comment` / `get_column_comment` for full text.
- **Single-item getters never truncate** — they remain the full-text escape hatch.

### 2. `SCALE_HINT_THRESHOLD = 100` — pagination cost guidance

`list_tables` emits `scale_hint` when `total_count > 100`, with the actual paginated round-trip count baked into the message. The continuous formulation (vs a hard threshold) lets the LLM weigh cost objectively while still suppressing noise for small schemas.

Example output:

```
"scale_hint": "This schema has 800 tables. Full enumeration would
need 16 paginated tool calls. Consider search_tables(keywords) or
/redshift-cache-schema for goal-oriented queries."
```

### 3. Server-level instructions

Two new paragraphs (`COMMENT TRUNCATION` and `SCALE GUIDANCE`) so the LLM understands both behaviors without having to parse field names from raw responses.

## Why these numbers

Picked from production cluster comment-length distribution (n=8534):

| | column comments | table comments |
|---|---|---|
| count | 7,870 | 664 |
| p50 | 11 chars | 204 chars |
| p95 | 46 chars | 1,517 chars |
| p99 | 88 chars | 2,714 chars |
| p100 | **471 chars** | **3,680 chars** |

- Cap at 1000 → never bites columns (p100=471), truncates ~9% of the dbt-generated marts/intermediate table description long tail.
- Cap at 500 (rejected) → cuts 18% of table comments unnecessarily.
- Cap at 2000 (rejected) → only avoids 5% more truncations, doubles worst-case payload.

## Test plan

- [x] 15 new unit tests covering: helper edge cases, scale_hint above/below threshold, truncation appears/doesn't appear in tool responses, single-item getters return full untruncated text
- [x] All 236 tests pass (221 existing + 15 new)
- [ ] Reviewer: confirm the ellipsis marker `…` (U+2026) renders cleanly in your tooling

## Notes

- API surface change: response dicts may gain `comment_truncated_count`, `comment_truncated_hint`, `scale_hint` fields. All optional; absent means no truncation / no hint. Existing callers ignoring extra fields are unaffected.
- No SQL change. Truncation is pure Python post-processing on already-fetched results.
- Builds on #22 (the SQL rewrite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)