### PR TITLE
feat: cross-scope search — two new skills + MCP tool extension for schema-wide / cluster-wide search

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -61,6 +61,8 @@ list / search はすべてページング対応。コメントを読んでから
 | [/redshift-cache-schema](skills/redshift-cache-schema/) | LLM 内部キャッシュ: クラスタ構造をローカルファイルにダンプし、後続のスキル呼び出しでメタデータを高速に解決。 | v0.3.0 |
 | [/redshift-explore](skills/redshift-explore/) | 三段ウィザード（schema → table → column）— 名前を覚えるのではなくコメントを読んで選ぶ。 | v0.3.0 |
 | [/redshift-lineage-from-stl](skills/redshift-lineage-from-stl/) | `STL_QUERY` + sqlglot を採掘してクエリ履歴から **実際の** テーブル間系譜を再構築。 | v0.3.0 |
+| [/redshift-grep-columns](skills/redshift-grep-columns/) | 1 つまたは全スキーマを横断してカラム名／コメントをキーワード検索。キャッシュ優先（ローカル TSV grep）／ライブ MCP フォールバック。 | v0.4.0 |
+| [/redshift-grep-tables](skills/redshift-grep-tables/) | 全スキーマを横断してテーブル名／コメントをキーワード検索。キャッシュ優先（ローカル TSV grep）／ライブ MCP フォールバック。 | v0.4.0 |
 
 各スキルはフォルダ内に三言語 README を持っています（ただし
 `/redshift-setup` と `/redshift-switch-profile` はセットアップ系内部

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ the LLM to read comments before trusting names.
 | [/redshift-cache-schema](skills/redshift-cache-schema/) | LLM-internal cache: dumps cluster structure to local files for faster metadata lookups in subsequent skill invocations. | v0.3.0 |
 | [/redshift-explore](skills/redshift-explore/) | Three-step interactive wizard (schema → table → column) — pick by reading comments. | v0.3.0 |
 | [/redshift-lineage-from-stl](skills/redshift-lineage-from-stl/) | Mine `STL_QUERY` + sqlglot to reconstruct **actual** table-to-table lineage from query history. | v0.3.0 |
+| [/redshift-grep-columns](skills/redshift-grep-columns/) | Cross-table column search by keyword across one or all schemas. Cache-first via local TSV grep; live MCP fallback. | v0.4.0 |
+| [/redshift-grep-tables](skills/redshift-grep-tables/) | Cross-schema table search by keyword across all schemas. Cache-first via local TSV grep; live MCP fallback. | v0.4.0 |
 
 Each skill has its own tri-lingual README inside its folder (except
 `/redshift-setup` and `/redshift-switch-profile`, which are setup-style

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -57,6 +57,8 @@ manifest 涵蓋面太窄、Web GUI 太慢、手刻 SQL 太重複。
 | [/redshift-cache-schema](skills/redshift-cache-schema/) | LLM 內部 cache：把 cluster 結構寫到本地檔，讓後續 skill 呼叫能快速解析 metadata。 | v0.3.0 |
 | [/redshift-explore](skills/redshift-explore/) | 三步 wizard（schema → table → column）—— 讀註解來挑，不用記名字。 | v0.3.0 |
 | [/redshift-lineage-from-stl](skills/redshift-lineage-from-stl/) | 挖 `STL_QUERY` + sqlglot 從查詢歷史還原**實際**的 table 對 table 資料流。 | v0.3.0 |
+| [/redshift-grep-columns](skills/redshift-grep-columns/) | 跨表搜欄位（名稱 + 註解），可在單一或全部 schema 上執行。Cache-first 走本地 TSV grep；live MCP fallback。 | v0.4.0 |
+| [/redshift-grep-tables](skills/redshift-grep-tables/) | 跨 schema 搜表（名稱 + 註解）。Cache-first 走本地 TSV grep；live MCP fallback。 | v0.4.0 |
 
 每支 skill 在自己的資料夾內都有三語 README（除了 `/redshift-setup` 與
 `/redshift-switch-profile` 屬於 setup-style 內部 skill —— 直接看 SKILL.md）。

--- a/commands/redshift-grep-columns.md
+++ b/commands/redshift-grep-columns.md
@@ -1,0 +1,11 @@
+---
+description: "Cross-table column search — find every column whose name or comment matches a keyword across all tables in one (or all) schemas. Cache-first, live MCP fallback. Composes the redshift-comment-mcp tools."
+---
+
+Use the redshift-comment-mcp:redshift-grep-columns skill to find columns by keyword across many tables. Argument forms accepted:
+
+- `/redshift-grep-columns <keyword>`                          (all schemas)
+- `/redshift-grep-columns <keyword> --schema <s>`             (scope to one schema)
+- `/redshift-grep-columns <keyword> --schema <s1>,<s2>`       (scope to listed schemas)
+- `/redshift-grep-columns <kw1> <kw2>`                        (AND across keywords)
+- `/redshift-grep-columns <keyword> --max-list 30`            (results per page)

--- a/commands/redshift-grep-tables.md
+++ b/commands/redshift-grep-tables.md
@@ -1,0 +1,10 @@
+---
+description: "Cross-schema table search — find every table whose name or comment matches a keyword across all schemas in the cluster. Cache-first, live MCP fallback. Composes the redshift-comment-mcp tools."
+---
+
+Use the redshift-comment-mcp:redshift-grep-tables skill to find tables by keyword across all schemas. Argument forms accepted:
+
+- `/redshift-grep-tables <keyword>`                       (all schemas)
+- `/redshift-grep-tables <keyword> --schema <s1>,<s2>`    (scope to listed schemas)
+- `/redshift-grep-tables <kw1> <kw2>`                     (AND across keywords)
+- `/redshift-grep-tables <keyword> --max-list 30`         (results per page)

--- a/skills/README.md
+++ b/skills/README.md
@@ -37,6 +37,8 @@ What you will NOT find here:
 | [redshift-cache-schema](redshift-cache-schema/) | LLM-internal cache: dumps cluster structure to local files so other skills resolve metadata via Read instead of MCP round-trips. Read by `/redshift-explore`, `/redshift-profile`, and the server-level CACHE PROTOCOL. | v0.3.0 |
 | [redshift-explore](redshift-explore/) | Three-step interactive wizard (schema → table → column) that lets users pick by reading comments instead of remembering names. | v0.3.0 |
 | [redshift-lineage-from-stl](redshift-lineage-from-stl/) | Mine `STL_QUERY` / `SYS_QUERY_HISTORY` + parse SQL with sqlglot to reconstruct *actual* table-to-table data flow from query history. | v0.3.0 |
+| [redshift-grep-columns](redshift-grep-columns/) | Cross-table column search by keyword (name + comment) across one or all schemas. Cache-first via local TSV grep; live MCP fallback. | v0.4.0 |
+| [redshift-grep-tables](redshift-grep-tables/) | Cross-schema table search by keyword (name + comment) across all schemas. Cache-first via local TSV grep; live MCP fallback. | v0.4.0 |
 
 ## How to use
 

--- a/skills/redshift-cache-schema/SKILL.md
+++ b/skills/redshift-cache-schema/SKILL.md
@@ -198,3 +198,5 @@ Cache dir created with `mkdir -p`, mode 700.
 | Interactive schema walk (uses this cache when fresh, falls back to MCP) | `/redshift-explore` |
 | Profile a column's values (uses this cache for column metadata) | `/redshift-profile` |
 | Mine actual usage from query history | `/redshift-lineage-from-stl` |
+| Cross-table column grep (heavy beneficiary of this cache) | `/redshift-grep-columns` |
+| Cross-schema table grep (heavy beneficiary of this cache) | `/redshift-grep-tables` |

--- a/skills/redshift-explore/SKILL.md
+++ b/skills/redshift-explore/SKILL.md
@@ -144,3 +144,5 @@ Step 4 produces the downstream skill's output.
 |---|---|
 | Profile a column once you have it | `/redshift-profile` |
 | Prime / refresh the cache for faster metadata reads | `/redshift-cache-schema` |
+| Find a column across many tables (FK / JOIN reconnaissance) | `/redshift-grep-columns` |
+| Find a table across schemas by topic | `/redshift-grep-tables` |

--- a/skills/redshift-grep-columns/README.ja.md
+++ b/skills/redshift-grep-columns/README.ja.md
@@ -1,0 +1,48 @@
+# redshift-grep-columns
+
+[English](README.md) · **日本語** · [繁體中文](README.zh-TW.md)
+
+## 何ができるか
+
+`redshift-grep-columns` は「このキーワードを含むカラムはどのテーブルにあるか？」という質問に答えます。Redshift クラスタ内の 1 つまたは全スキーマのカラムメタデータを横断検索し、カラム名とコメントの両方を対象にマッチします。結果は `<schema>.<table>` ごとにグループ化され、型とコメントを併記します。
+
+キャッシュ優先：`/redshift-cache-schema` で生成された TSV インデックスが新鮮なら、`bash grep` で約 50 ms で応答します。キャッシュが古い／ない場合はライブ MCP（`search_tables` + マッチしたテーブルごとの `search_columns`）にフォールバックしますが、ラウンドトリップが多くなります。
+
+## 使うべきとき
+
+複数テーブルにまたがる SQL を組む直前に使います。特に共有キー／FK 候補をテーブル横断で特定する場面で有用です。典型例：
+
+- JOIN 前の偵察：「`customers` への FK としてコメントされているカラム全部」
+- 命名一貫性の監査：「`customer_id` と `cust_no`、どちらを使っている？両方混在している？」
+- メトリクス位置探し：「`gross_margin` を出しているテーブルはどれ？」
+
+単一テーブル内の検索には不向き（MCP `search_columns(kw, schema, table)` を直接使う）。単一カラムの全文取得は `get_column_comment`、テーブル名検索は `/redshift-grep-tables` を使ってください。
+
+## 例
+
+```
+/redshift-grep-columns customer_id --schema dbt_marts
+```
+
+チャット応答例：
+
+> Matches for "customer_id" (4 hits in 1 schema, 3 tables):
+>
+> dbt_marts.fct_orders
+>   customer_id   bigint   Customer reference (FK to dim_users.id)
+>
+> dbt_marts.fct_returns
+>   customer_id   bigint   Customer who initiated the return
+>
+> dbt_marts.dim_users
+>   id            bigint   Primary key, referenced as customer_id elsewhere
+>   cust_no       bigint   Legacy customer number, alias for id
+
+## パフォーマンス注意
+
+スキーマ 5 個以上のクラスタでキャッシュが古いまま grep しようとしていますか？
+先に `/redshift-cache-schema` を実行してください。ライブパスのコストはスキーマ数とマッチしたテーブル数に比例しますが、キャッシュパスは定数時間です。
+
+## 詳細仕様
+
+入力パース規則・bash パターン・エラーコードの正典は [`SKILL.md`](./SKILL.md) を参照。

--- a/skills/redshift-grep-columns/README.md
+++ b/skills/redshift-grep-columns/README.md
@@ -1,0 +1,49 @@
+# redshift-grep-columns
+
+**English** · [日本語](README.ja.md) · [繁體中文](README.zh-TW.md)
+
+## What it does
+
+`redshift-grep-columns` answers the question *"which tables have a column matching this keyword?"* by grepping across the column metadata of one or all schemas in a Redshift cluster. It searches both column names AND column comments, returning every hit grouped by `<schema>.<table>` with the column type and comment inline.
+
+Cache-first: when `/redshift-cache-schema` has produced a fresh local TSV index, this skill answers in roughly 50 ms via `bash grep`. When the cache is stale or absent, it falls back to live MCP (`search_tables` + `search_columns` per matching table), which can take many round trips.
+
+## When to use it
+
+Reach for this skill before composing a multi-table SQL query — particularly when you need to identify shared keys / FK candidates across tables. Typical scenarios:
+
+- Pre-JOIN reconnaissance: "find every column commented as a foreign key to `customers`."
+- Naming-consistency audits: "are we calling it `customer_id`, `cust_no`, or both?"
+- Locating a metric: "which tables expose `gross_margin`?"
+
+Skip it for single-table column lookups (use MCP `search_columns(kw, schema, table)` directly), single-column lookup with full text (use `get_column_comment`), or table-name search (use `/redshift-grep-tables`).
+
+## Example
+
+```
+/redshift-grep-columns customer_id --schema dbt_marts
+```
+
+Sample chat reply:
+
+> Matches for "customer_id" (4 hits in 1 schema, 3 tables):
+>
+> dbt_marts.fct_orders
+>   customer_id   bigint   Customer reference (FK to dim_users.id)
+>
+> dbt_marts.fct_returns
+>   customer_id   bigint   Customer who initiated the return
+>
+> dbt_marts.dim_users
+>   id            bigint   Primary key, referenced as customer_id elsewhere
+>   cust_no       bigint   Legacy customer number, alias for id
+
+## Performance note
+
+Cluster has > 5 schemas and you're about to grep without a fresh cache?
+Run `/redshift-cache-schema` first. Live-path cost scales linearly with
+schema and matching-table counts; cache-path cost is constant.
+
+## Authoritative reference
+
+For execution details — input parsing rules, exact bash patterns, error codes — see [`SKILL.md`](./SKILL.md).

--- a/skills/redshift-grep-columns/README.zh-TW.md
+++ b/skills/redshift-grep-columns/README.zh-TW.md
@@ -1,0 +1,47 @@
+# redshift-grep-columns
+
+[English](README.md) · [日本語](README.ja.md) · **繁體中文**
+
+## 它做什麼
+
+`redshift-grep-columns` 回答「哪些表有符合這個關鍵字的欄位？」這個問題。它在 Redshift cluster 內的單一或全部 schema 上跨表搜尋欄位元數據，**同時比對欄位名稱與欄位註解**，命中結果按 `<schema>.<table>` 分組呈現，附帶型別與註解。
+
+Cache-first 設計：當 `/redshift-cache-schema` 已產出新鮮的本地 TSV 索引，這個 skill 會用 `bash grep` 在約 50 ms 內回應。若 cache 過期或缺失，回退到 live MCP（`search_tables` + 對每張命中表跑 `search_columns`），這條路會多次 round trip。
+
+## 何時該用
+
+組多表 SQL 之前使用，特別是要在多張表之間找出共用鍵 / FK 候選的情境。典型場景：
+
+- JOIN 前偵察：「找所有註解寫著 FK to `customers` 的欄位」
+- 命名一致性審計：「我們是用 `customer_id` 還是 `cust_no`？兩個都有嗎？」
+- 找指標欄位：「哪些表有 `gross_margin`？」
+
+不適合：單一已知表內的搜尋（直接用 MCP `search_columns(kw, schema, table)`）、單一欄位全文（用 `get_column_comment`）、找表名（用 `/redshift-grep-tables`）。
+
+## 範例
+
+```
+/redshift-grep-columns customer_id --schema dbt_marts
+```
+
+聊天回應範例：
+
+> Matches for "customer_id" (4 hits in 1 schema, 3 tables):
+>
+> dbt_marts.fct_orders
+>   customer_id   bigint   Customer reference (FK to dim_users.id)
+>
+> dbt_marts.fct_returns
+>   customer_id   bigint   Customer who initiated the return
+>
+> dbt_marts.dim_users
+>   id            bigint   Primary key, referenced as customer_id elsewhere
+>   cust_no       bigint   Legacy customer number, alias for id
+
+## 效能注意
+
+cluster 有 5 個以上 schema 且 cache 不新鮮？先跑 `/redshift-cache-schema`。Live 路徑成本隨 schema 數與命中表數線性增長；cache 路徑是常數時間。
+
+## 詳細規格
+
+輸入解析規則、bash 模板、錯誤代碼的正典在 [`SKILL.md`](./SKILL.md)。

--- a/skills/redshift-grep-columns/SKILL.md
+++ b/skills/redshift-grep-columns/SKILL.md
@@ -79,24 +79,29 @@ shell metacharacters (`-`, `*`, `$`, etc. in user input).
 
 ### Step 1b — live MCP path (fallback)
 
-Used when `cache=miss/stale`. Strongly prefer prompting the user to
-prime the cache first if the cluster has > 5 schemas — live path costs
-many round trips.
+Used when `cache=miss/stale`. The MCP server's `search_columns` accepts an
+optional `table_name`; omit it for **schema-wide column search in one call**:
+
+```
+search_columns(keywords, schema_name=<schema>, table_name=None)
+```
+
+This returns one row per matching column with `table_name` included, ranked
+by `hit_count` across name + comment. Paginate via `has_more` if total > 50.
 
 Procedure:
-- If `--schema` given: skip schema enumeration; iterate the listed schemas.
-- Else: `list_schemas(include_comments=true)` → schema list.
-- Per schema: `search_tables(keywords, schema_name)` → candidate tables that
-  may contain matching columns (because comment search at table-level catches
-  tables with relevant business meaning even if the column name itself
-  doesn't match).
-- Per candidate table: `search_columns(keywords, schema_name, table_name)` →
-  matching columns. Page through `has_more` per call.
-- Aggregate all hits into one rendered list.
+- If `--schema` given: one call per listed schema.
+- Else: `list_schemas(include_comments=true)` → enumerate user schemas;
+  one `search_columns` per schema (schema-wide each).
+- Aggregate.
 
-Worst-case round trips on an 800-table single-schema cluster: 1 (search_tables)
-+ N (search_columns per matching table). Easily 30+ trips. Cache path costs
-exactly 1 grep.
+Latency on the live path is ~0.7s per schema-wide call (12K-column schemas).
+Compare to the cache path (~50ms via local TSV grep) — the live fallback is
+~14x slower than cache-hit but ~27x faster than the legacy approach of
+orchestrating `search_tables` + per-table `search_columns` (which costs N
+round trips on N matching tables, easily 19s+ on big schemas).
+
+Still emit the cache hint so user knows to prime for next time.
 
 ### Step 2 — render
 
@@ -126,7 +131,7 @@ If the user wants to profile one of the columns, suggest
 
 ## Anti-patterns
 
-- NEVER pump live MCP through a 100+ table schema as a substitute for the cache. Emit the cache hint and STOP after one schema's worth if cache is stale.
+- NEVER orchestrate `search_tables` + per-table `search_columns` as the live fallback — use `search_columns(keywords, schema_name, table_name=None)` for one-shot schema-wide search. The orchestration approach is ~27x slower and the legacy code path it replaced.
 - NEVER strip the `<schema>.<table>` prefix when rendering — same column name across tables IS the value of cross-table grep.
 - NEVER omit the cache freshness hint — a stale cache silently lying about FK relationships is the known risk for JOIN-discovery work.
 - NEVER use `grep` without `--` and single-quoted keyword — user keywords with leading `-` or shell metacharacters will misbehave.

--- a/skills/redshift-grep-columns/SKILL.md
+++ b/skills/redshift-grep-columns/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: redshift-grep-columns
+description: >-
+  Cross-table column search — finds every column whose name or comment
+  matches a keyword across all tables in one (or all) schemas.
+  Cache-first (~50ms via local TSV grep); falls back to live MCP when
+  cache is stale or absent. Use when user wants to find FK / shared-key
+  columns across many tables (e.g. before composing a JOIN), or to
+  audit column-naming consistency. Do NOT use for a single known table
+  (use search_columns directly), single-column lookup (use
+  get_column_comment), or table-name search (use /redshift-grep-tables).
+  Triggers: /redshift-grep-columns / find column / search columns
+  across tables / where is foo column / 跨表找欄位 / 哪些表有 foo /
+  カラム横断検索 / カラム名検索.
+---
+
+# Redshift Cross-Table Column Grep
+
+Find every column whose name or comment matches a keyword across all
+tables in one or all schemas. Cache-first; live MCP fallback.
+
+## When to use / NOT
+- Use to find FK / shared-key columns across many tables (typical
+  pre-JOIN reconnaissance).
+- Use to audit naming consistency ("are we calling this `customer_id`
+  or `cust_no`?").
+- NOT for a single known table — use MCP `search_columns(kw, schema, table)` directly.
+- NOT for single-column lookup — use MCP `get_column_comment`.
+- NOT for table-name search — use `/redshift-grep-tables`.
+
+## Inputs
+| Form | Behavior |
+|---|---|
+| `<keyword>` | grep across all schemas in the cluster |
+| `<keyword> --schema <name>` | scope to one schema |
+| `<keyword> --schema <s1>,<s2>` | scope to listed schemas |
+| `<kw1> <kw2>` | AND across keywords (both must match) |
+| `--max-list N` | results per page (default 50) |
+
+## Flow
+
+### Step 0 — cache lookup
+
+Read `~/.cache/redshift-comment-mcp/<profile>/_meta.json`. If the file
+exists, `complete: true`, and `(now - refreshed_at) < ttl_hours`, set
+`cache=fresh` and use the cache path below. Otherwise emit one chat line:
+
+```
+[cache] miss / stale — falling back to live search; rebuild with /redshift-cache-schema --refresh.
+```
+
+`<profile>` resolves from `~/.config/redshift-comment-mcp/active-profile`
+(default `default`).
+
+### Step 1a — cache path (preferred)
+
+`_columns_index.tsv` columns: `schema\ttable\tcolumn\ttype\tsummary`,
+header on line 1.
+
+```bash
+PROFILE=$(cat ~/.config/redshift-comment-mcp/active-profile 2>/dev/null || echo default)
+INDEX=~/.cache/redshift-comment-mcp/$PROFILE/_columns_index.tsv
+
+# single keyword, all schemas
+grep -i -- 'KEYWORD' "$INDEX" | head -50
+
+# multi-keyword AND
+grep -i -- 'KW1' "$INDEX" | grep -i -- 'KW2' | head -50
+
+# scoped to one schema
+awk -F'\t' '$1 == "SCHEMA"' "$INDEX" | grep -i -- 'KEYWORD' | head -50
+
+# scoped to multiple schemas
+awk -F'\t' '$1 == "S1" || $1 == "S2"' "$INDEX" | grep -i -- 'KEYWORD' | head -50
+```
+
+Always pass `--` to `grep` and single-quote the keyword to neutralize
+shell metacharacters (`-`, `*`, `$`, etc. in user input).
+
+### Step 1b — live MCP path (fallback)
+
+Used when `cache=miss/stale`. Strongly prefer prompting the user to
+prime the cache first if the cluster has > 5 schemas — live path costs
+many round trips.
+
+Procedure:
+- If `--schema` given: skip schema enumeration; iterate the listed schemas.
+- Else: `list_schemas(include_comments=true)` → schema list.
+- Per schema: `search_tables(keywords, schema_name)` → candidate tables that
+  may contain matching columns (because comment search at table-level catches
+  tables with relevant business meaning even if the column name itself
+  doesn't match).
+- Per candidate table: `search_columns(keywords, schema_name, table_name)` →
+  matching columns. Page through `has_more` per call.
+- Aggregate all hits into one rendered list.
+
+Worst-case round trips on an 800-table single-schema cluster: 1 (search_tables)
++ N (search_columns per matching table). Easily 30+ trips. Cache path costs
+exactly 1 grep.
+
+### Step 2 — render
+
+Group by `<schema>.<table>`, comment-first. One blank line between groups:
+
+```
+Matches for "customer_id" (12 hits in 3 schemas, 8 tables):
+
+dbt_marts.fct_orders
+  customer_id   bigint   Customer reference (FK to dim_users.id)
+
+dbt_marts.fct_returns
+  customer_id   bigint   Customer who initiated the return
+
+dbt_staging.stg_users
+  id            bigint   Customer's primary key
+  cust_no       bigint   Legacy customer no, alias for id
+```
+
+Cap at 50 results per page; show `1-50 of 87, reply 'more'` when truncated.
+
+## Output
+
+Rendered list IS the output. No JSON. Hand off to user to pick a target.
+If the user wants to profile one of the columns, suggest
+`/redshift-profile <schema>.<table> <column>`.
+
+## Anti-patterns
+
+- NEVER pump live MCP through a 100+ table schema as a substitute for the cache. Emit the cache hint and STOP after one schema's worth if cache is stale.
+- NEVER strip the `<schema>.<table>` prefix when rendering — same column name across tables IS the value of cross-table grep.
+- NEVER omit the cache freshness hint — a stale cache silently lying about FK relationships is the known risk for JOIN-discovery work.
+- NEVER use `grep` without `--` and single-quoted keyword — user keywords with leading `-` or shell metacharacters will misbehave.
+
+## Errors
+| Condition | Behavior |
+|---|---|
+| Empty keyword | refuse with usage hint |
+| Cache miss + cluster has > 5 schemas | emit hint, ask user to confirm before proceeding live |
+| `--schema` doesn't exist | fail with the schema name + suggestion to run `/redshift-cache-schema` or check spelling |
+| Live MCP returns 0 hits everywhere | "No matches; broaden keyword?" |
+| Cache file unreadable | fall through to live path with a one-line warning |
+
+## See also
+
+| Need | Use |
+|---|---|
+| Search tables by name/comment across schemas | `/redshift-grep-tables` |
+| Browse interactively from zero context | `/redshift-explore` |
+| Prime the cache for fast grep | `/redshift-cache-schema` |
+| Profile a column's values once located | `/redshift-profile` |

--- a/skills/redshift-grep-tables/README.ja.md
+++ b/skills/redshift-grep-tables/README.ja.md
@@ -1,0 +1,49 @@
+# redshift-grep-tables
+
+[English](README.md) · **日本語** · [繁體中文](README.zh-TW.md)
+
+## 何ができるか
+
+`redshift-grep-tables` は「X についてのテーブルはどのスキーマにある？」という質問に答えます。Redshift クラスタ内の全スキーマのテーブルメタデータを横断検索し、テーブル名とコメントの両方を対象にマッチします。結果はスキーマごとにグループ化され、テーブル型とコメントを併記します。
+
+キャッシュ優先：`/redshift-cache-schema` で生成された TSV インデックスが新鮮なら、`bash grep` で約 50 ms で応答します。キャッシュが古い／ない場合はライブ MCP（スキーマごとに 1 回 `search_tables` を呼ぶ）にフォールバックし、スキーマ数に比例してコストが増えます。
+
+## 使うべきとき
+
+トピックは分かるが、どのスキーマにあるか不明なときに使います。多層構造（ingestion / staging / mart）を持つ不慣れなクラスタで特に有用です。典型例：
+
+- トピック検索：「orders fact テーブルはどこ？」
+- レイヤー横断監査：「`fct_*` テーブルがあるスキーマはどれ？」
+- ベンダーカバレッジ確認：「Salesforce を取り込んでいるスキーマはどこ？」
+
+スキーマが既に分かっている場合は不向き（MCP `search_tables(kw, schema)` を直接使う）。カラム検索は `/redshift-grep-columns`、一般的なスキーマ閲覧は `/redshift-explore` を使ってください。
+
+## 例
+
+```
+/redshift-grep-tables fct
+```
+
+チャット応答例：
+
+> Tables matching "fct" (5 hits in 3 schemas):
+>
+> dbt_marts (3)
+>   fct_orders          BASE TABLE   Central order facts.
+>   fct_returns         BASE TABLE   Return events.
+>   fct_payments        BASE TABLE   Payment events.
+>
+> dbt_staging (1)
+>   stg_fct_orders      BASE TABLE   Staging for fct_orders.
+>
+> reporting (1)
+>   v_fct_orders_daily  VIEW         Daily aggregation of fct_orders.
+
+## パフォーマンス注意
+
+スキーマ 10 個以上のクラスタでキャッシュが古いまま grep しようとしていますか？
+先に `/redshift-cache-schema` を実行してください。ライブパスはスキーマごとに 1 ツール呼び出し。キャッシュパスは合計 50 ms。
+
+## 詳細仕様
+
+入力パース規則・bash パターン・エラーコードの正典は [`SKILL.md`](./SKILL.md) を参照。

--- a/skills/redshift-grep-tables/README.md
+++ b/skills/redshift-grep-tables/README.md
@@ -1,0 +1,50 @@
+# redshift-grep-tables
+
+**English** · [日本語](README.ja.md) · [繁體中文](README.zh-TW.md)
+
+## What it does
+
+`redshift-grep-tables` answers the question *"which schema has a table about X?"* by grepping across the table metadata of all schemas in a Redshift cluster. It searches both table names AND table comments, returning every hit grouped by schema with the table type and comment inline.
+
+Cache-first: when `/redshift-cache-schema` has produced a fresh local TSV index, this skill answers in roughly 50 ms via `bash grep`. When the cache is stale or absent, it falls back to live MCP (one `search_tables` call per schema), which scales linearly with schema count.
+
+## When to use it
+
+Reach for this skill when you know the topic but not the schema — typical of working on an unfamiliar cluster or one that mixes ingestion / staging / mart layers across many namespaces. Typical scenarios:
+
+- Topic search: "where is the orders fact?"
+- Layer-spanning audit: "which schemas have a `fct_*` table?"
+- Vendor-coverage check: "which schemas ingest from Salesforce?"
+
+Skip it when the schema is already known (use MCP `search_tables(kw, schema)` directly), for column-level search (use `/redshift-grep-columns`), or for general schema browsing (use `/redshift-explore`).
+
+## Example
+
+```
+/redshift-grep-tables fct
+```
+
+Sample chat reply:
+
+> Tables matching "fct" (5 hits in 3 schemas):
+>
+> dbt_marts (3)
+>   fct_orders          BASE TABLE   Central order facts.
+>   fct_returns         BASE TABLE   Return events.
+>   fct_payments        BASE TABLE   Payment events.
+>
+> dbt_staging (1)
+>   stg_fct_orders      BASE TABLE   Staging for fct_orders.
+>
+> reporting (1)
+>   v_fct_orders_daily  VIEW         Daily aggregation of fct_orders.
+
+## Performance note
+
+Cluster has 10+ schemas and you're about to grep without a fresh cache?
+Run `/redshift-cache-schema` first. Live path costs one tool call per
+schema; cache path costs 50 ms total.
+
+## Authoritative reference
+
+For execution details — input parsing rules, exact bash patterns, error codes — see [`SKILL.md`](./SKILL.md).

--- a/skills/redshift-grep-tables/README.zh-TW.md
+++ b/skills/redshift-grep-tables/README.zh-TW.md
@@ -1,0 +1,48 @@
+# redshift-grep-tables
+
+[English](README.md) · [日本語](README.ja.md) · **繁體中文**
+
+## 它做什麼
+
+`redshift-grep-tables` 回答「關於 X 的表在哪個 schema？」這個問題。它在 Redshift cluster 內的所有 schema 上跨範圍搜尋表元數據，**同時比對表名稱與表註解**，命中結果按 schema 分組呈現，附帶表類型與註解。
+
+Cache-first 設計：當 `/redshift-cache-schema` 已產出新鮮的本地 TSV 索引，這個 skill 會用 `bash grep` 在約 50 ms 內回應。若 cache 過期或缺失，回退到 live MCP（每個 schema 跑一次 `search_tables`），成本隨 schema 數量線性增長。
+
+## 何時該用
+
+知道主題但不確定在哪個 schema 時用。多層架構（ingestion / staging / mart）混合多 namespace 的不熟悉 cluster 特別適用。典型場景：
+
+- 主題搜尋：「orders fact 表在哪？」
+- 跨層審計：「哪些 schema 有 `fct_*` 表？」
+- 廠商覆蓋確認：「哪些 schema 在做 Salesforce 的 ingestion？」
+
+不適合：schema 已知（直接用 MCP `search_tables(kw, schema)`）、欄位層級搜尋（用 `/redshift-grep-columns`）、一般 schema 瀏覽（用 `/redshift-explore`）。
+
+## 範例
+
+```
+/redshift-grep-tables fct
+```
+
+聊天回應範例：
+
+> Tables matching "fct" (5 hits in 3 schemas):
+>
+> dbt_marts (3)
+>   fct_orders          BASE TABLE   Central order facts.
+>   fct_returns         BASE TABLE   Return events.
+>   fct_payments        BASE TABLE   Payment events.
+>
+> dbt_staging (1)
+>   stg_fct_orders      BASE TABLE   Staging for fct_orders.
+>
+> reporting (1)
+>   v_fct_orders_daily  VIEW         Daily aggregation of fct_orders.
+
+## 效能注意
+
+cluster 有 10 個以上 schema 且 cache 不新鮮？先跑 `/redshift-cache-schema`。Live 路徑成本是「每 schema 一次 tool call」；cache 路徑全程 50 ms。
+
+## 詳細規格
+
+輸入解析規則、bash 模板、錯誤代碼的正典在 [`SKILL.md`](./SKILL.md)。

--- a/skills/redshift-grep-tables/SKILL.md
+++ b/skills/redshift-grep-tables/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: redshift-grep-tables
+description: >-
+  Cross-schema table search — finds every table whose name or comment
+  matches a keyword, across all schemas in the cluster. Cache-first
+  (~50ms via local TSV grep); live MCP fallback (one search_tables
+  call per schema, slower for many-schema clusters). Use when user is
+  looking for a table by topic but unsure which schema (e.g. "where
+  is the orders fact table"), or auditing table-naming consistency.
+  Do NOT use when schema is already known (use search_tables directly),
+  for column-level search (use /redshift-grep-columns), or for general
+  schema browsing (use /redshift-explore). Triggers:
+  /redshift-grep-tables / find table / search tables / which schema
+  has / 哪個 schema 有 / 跨 schema 找表 / テーブル横断検索 /
+  テーブル名検索.
+---
+
+# Redshift Cross-Schema Table Grep
+
+Find every table whose name or comment matches a keyword across all
+schemas in the cluster. Cache-first; live MCP fallback.
+
+## When to use / NOT
+- Use to find a table by topic when schema is unknown ("where is the
+  orders fact?").
+- Use to audit table-naming consistency across schemas.
+- NOT when schema is already known — use MCP `search_tables(kw, schema)` directly.
+- NOT for column-level search — use `/redshift-grep-columns`.
+- NOT for general schema browsing — use `/redshift-explore`.
+
+## Inputs
+| Form | Behavior |
+|---|---|
+| `<keyword>` | grep across all schemas |
+| `<keyword> --schema <s1>,<s2>` | scope to listed schemas |
+| `<kw1> <kw2>` | AND across keywords (both must match) |
+| `--max-list N` | results per page (default 50) |
+
+## Flow
+
+### Step 0 — cache lookup
+
+Read `~/.cache/redshift-comment-mcp/<profile>/_meta.json`. If the file
+exists, `complete: true`, and `(now - refreshed_at) < ttl_hours`, set
+`cache=fresh` and use the cache path. Otherwise emit:
+
+```
+[cache] miss / stale — falling back to live search; rebuild with /redshift-cache-schema --refresh.
+```
+
+`<profile>` resolves from `~/.config/redshift-comment-mcp/active-profile`
+(default `default`).
+
+### Step 1a — cache path (preferred)
+
+`_tables_index.tsv` columns: `schema\ttable\tsummary`, header on line 1.
+
+```bash
+PROFILE=$(cat ~/.config/redshift-comment-mcp/active-profile 2>/dev/null || echo default)
+INDEX=~/.cache/redshift-comment-mcp/$PROFILE/_tables_index.tsv
+
+# single keyword, all schemas
+grep -i -- 'KEYWORD' "$INDEX" | head -50
+
+# multi-keyword AND
+grep -i -- 'KW1' "$INDEX" | grep -i -- 'KW2' | head -50
+
+# scoped to listed schemas
+awk -F'\t' '$1 == "S1" || $1 == "S2"' "$INDEX" | grep -i -- 'KEYWORD' | head -50
+```
+
+Always pass `--` to `grep` and single-quote the keyword to neutralize
+shell metacharacters in user input.
+
+### Step 1b — live MCP path (fallback)
+
+Used when `cache=miss/stale`. Worst-case round trips: 1 (`list_schemas`)
++ N (one `search_tables` per schema in scope). For a cluster with 20+
+schemas, this is 20+ tool calls. Strongly prefer prompting the user to
+run `/redshift-cache-schema` first.
+
+Procedure:
+- `list_schemas(include_comments=true)` → schema list. Filter by
+  `--schema` if given.
+- Per schema: `search_tables(keywords, schema_name)` → matching tables.
+  Page through `has_more` per call.
+- Aggregate all hits into one rendered list.
+
+### Step 2 — render
+
+Group by schema, count per schema in header line, comment-first body.
+One blank line between groups:
+
+```
+Tables matching "fct" (8 hits in 4 schemas):
+
+dbt_marts (3)
+  fct_orders          BASE TABLE   Central order facts.
+  fct_returns         BASE TABLE   Return events.
+  fct_payments        BASE TABLE   Payment events.
+
+dbt_staging (2)
+  stg_fct_orders      BASE TABLE   Staging for fct_orders.
+  stg_fct_returns     BASE TABLE   Staging for fct_returns.
+
+raw_events (2)
+  fct_event_log       BASE TABLE   Raw event ingest.
+  fct_session_log     BASE TABLE   Session tracking.
+
+reporting (1)
+  v_fct_orders_daily  VIEW         Daily aggregation of fct_orders.
+```
+
+Cap at 50 results per page; show `1-50 of 87, reply 'more'` when truncated.
+
+## Output
+
+Rendered list IS the output. No JSON. Hand off to user to pick a target.
+If the user wants to drill into a chosen table, suggest
+`/redshift-explore <schema>.<table>`.
+
+## Anti-patterns
+
+- NEVER call `list_tables` for every schema as a substitute for `search_tables`. The MCP `search_tables` already filters at the SQL layer; `list_tables` then client-side filter is wasteful round trips.
+- NEVER omit the schema column in render — the whole point IS which schema has the table.
+- NEVER skip cache check — for clusters with 10+ schemas, live path costs N round trips; cache costs 50ms.
+- NEVER use `grep` without `--` and single-quoted keyword — user keywords with leading `-` or shell metacharacters will misbehave.
+
+## Errors
+| Condition | Behavior |
+|---|---|
+| Empty keyword | refuse with usage hint |
+| Cache miss + > 10 schemas | emit hint, ask user to confirm before proceeding live |
+| 0 hits across all schemas | "No tables match; broaden keyword?" |
+| `--schema` doesn't exist | fail with schema name + suggestion to check spelling |
+| Cache file unreadable | fall through to live path with a one-line warning |
+
+## See also
+
+| Need | Use |
+|---|---|
+| Cross-table column search | `/redshift-grep-columns` |
+| Search columns within a known table | use MCP `search_columns(kw, schema, table)` directly |
+| Browse interactively from zero context | `/redshift-explore` |
+| Prime the cache | `/redshift-cache-schema` |

--- a/skills/redshift-grep-tables/SKILL.md
+++ b/skills/redshift-grep-tables/SKILL.md
@@ -74,17 +74,30 @@ shell metacharacters in user input.
 
 ### Step 1b — live MCP path (fallback)
 
-Used when `cache=miss/stale`. Worst-case round trips: 1 (`list_schemas`)
-+ N (one `search_tables` per schema in scope). For a cluster with 20+
-schemas, this is 20+ tool calls. Strongly prefer prompting the user to
-run `/redshift-cache-schema` first.
+Used when `cache=miss/stale`. The MCP server's `search_tables` accepts an
+optional `schema_name`; omit it for **cluster-wide table search in one call**:
+
+```
+search_tables(keywords, schema_name=None)
+```
+
+This returns one row per matching table with `schema_name` included,
+ordered by `(schema_name, table_name)`. Paginate via `has_more` if
+total > 50.
 
 Procedure:
-- `list_schemas(include_comments=true)` → schema list. Filter by
-  `--schema` if given.
-- Per schema: `search_tables(keywords, schema_name)` → matching tables.
-  Page through `has_more` per call.
-- Aggregate all hits into one rendered list.
+- If `--schema <s1>,<s2>` given: one `search_tables` per listed schema
+  (cheap — typically a handful).
+- Else: one `search_tables(keywords, schema_name=None)` covers the
+  whole cluster.
+- Aggregate.
+
+Latency on the live path is ~0.2s for cluster-wide searches (cluster has
+<10K tables). Compare to cache path (~50ms via local TSV grep) — the live
+fallback is ~4x slower than cache-hit but vastly faster than the legacy
+N-call-per-schema approach.
+
+Still emit the cache hint so user knows to prime for next time.
 
 ### Step 2 — render
 
@@ -121,9 +134,10 @@ If the user wants to drill into a chosen table, suggest
 
 ## Anti-patterns
 
+- NEVER iterate `search_tables` per schema as the live fallback — use `search_tables(keywords, schema_name=None)` for one-shot cluster-wide search. The legacy iteration approach was N-calls-per-schema.
 - NEVER call `list_tables` for every schema as a substitute for `search_tables`. The MCP `search_tables` already filters at the SQL layer; `list_tables` then client-side filter is wasteful round trips.
 - NEVER omit the schema column in render — the whole point IS which schema has the table.
-- NEVER skip cache check — for clusters with 10+ schemas, live path costs N round trips; cache costs 50ms.
+- NEVER skip cache check — cache path is ~4x faster than even the optimized live path, and has zero leader-node load.
 - NEVER use `grep` without `--` and single-quoted keyword — user keywords with leading `-` or shell metacharacters will misbehave.
 
 ## Errors

--- a/src/redshift_comment_mcp/redshift_tools.py
+++ b/src/redshift_comment_mcp/redshift_tools.py
@@ -291,6 +291,14 @@ SEARCH KEYWORDS: search_schemas / search_tables / search_columns take
 space-separated keywords (OR logic). Pick keywords in the user's
 conversation language — comments usually match.
 
+SEARCH SCOPE:
+- search_tables(keywords, schema_name=None) — pass schema_name for
+  one schema (faster, narrower); omit it for cluster-wide search.
+- search_columns(keywords, schema_name, table_name=None) — pass
+  table_name for one-table drill-down; omit it for schema-wide
+  cross-table search (returns table_name on each row, the natural
+  primitive for FK / JOIN-key reconnaissance).
+
 For ad-hoc exploration, prefer list_* / search_* tools over execute_sql
 against information_schema — they include comments directly.
 
@@ -610,19 +618,22 @@ line suggesting /redshift-cache-schema --refresh.
             return result
 
         @self.mcp.tool
-        def search_tables(keywords: str, schema_name: str, limit: Optional[int] = None, offset: int = 0) -> Dict[str, Any]:
-            """Search tables in a given schema_name by keywords (space-separated, OR logic) over table name and comment."""
+        def search_tables(keywords: str, schema_name: Optional[str] = None, limit: Optional[int] = None, offset: int = 0) -> Dict[str, Any]:
+            """Search tables by keywords (space-separated, OR logic) over table name and comment.
+
+            Pass schema_name to scope to one schema (faster, narrower). Omit it to
+            search across all user schemas in the cluster (broader, slightly slower).
+            """
             # 解析關鍵字
             keyword_list = [k.strip() for k in keywords.split() if k.strip()]
             if not keyword_list:
                 raise ValueError("At least one keyword is required.")
 
-            # 驗證 schema_name
-            if not schema_name or not schema_name.isidentifier():
+            # schema_name 是可選的，但若提供必須是合法 identifier
+            if schema_name is not None and not schema_name.isidentifier():
                 raise ValueError("Invalid schema name.")
 
             # 建構 SQL - 使用參數化查詢防止 SQL injection
-            # 基礎查詢
             base_sql = """
             SELECT
                 n.nspname AS schema_name,
@@ -638,9 +649,10 @@ line suggesting /redshift-cache-schema --refresh.
               AND n.nspname <> 'information_schema'
             """
 
-            # 加入 schema 過濾條件（必填）
-            params = [schema_name]
-            base_sql += " AND n.nspname = %s"
+            params: list = []
+            if schema_name is not None:
+                base_sql += " AND n.nspname = %s"
+                params.append(schema_name)
 
             # 加入關鍵字搜尋條件（OR 邏輯）
             keyword_conditions = []
@@ -701,22 +713,31 @@ line suggesting /redshift-cache-schema --refresh.
             return result
 
         @self.mcp.tool
-        def search_columns(keywords: str, schema_name: str, table_name: str, limit: Optional[int] = None, offset: int = 0) -> Dict[str, Any]:
-            """Search columns in a given schema_name and table_name by keywords (space-separated, OR logic) over column name and comment."""
+        def search_columns(keywords: str, schema_name: str, table_name: Optional[str] = None, limit: Optional[int] = None, offset: int = 0) -> Dict[str, Any]:
+            """Search columns by keywords (space-separated, OR logic) over column name and comment.
+
+            schema_name is required. Pass table_name to scope to one table (cheap;
+            use this for routine drill-down). Omit table_name to search every table
+            in the schema (schema-wide; the natural primitive for cross-table FK /
+            JOIN-key reconnaissance, returns table_name on each row).
+            """
             # 解析關鍵字
             keyword_list = [k.strip() for k in keywords.split() if k.strip()]
             if not keyword_list:
                 raise ValueError("At least one keyword is required.")
 
-            # 驗證 schema_name 和 table_name
+            # schema 必填且需是合法 identifier
             if not schema_name or not schema_name.isidentifier():
                 raise ValueError("Invalid schema name.")
-            if not table_name or not table_name.isidentifier():
+            # table_name 可選；若提供必須是合法 identifier
+            if table_name is not None and not table_name.isidentifier():
                 raise ValueError("Invalid table name.")
 
             # 建構 SQL - 使用參數化查詢防止 SQL injection
+            # schema-wide 模式回傳 table_name；single-table 模式為了向後相容也帶上
             base_sql = """
             SELECT
+                c.table_name,
                 c.column_name,
                 c.data_type,
                 c.is_nullable,
@@ -725,11 +746,13 @@ line suggesting /redshift-cache-schema --refresh.
             LEFT JOIN pg_namespace n ON n.nspname = c.table_schema
             LEFT JOIN pg_class cl ON cl.relname = c.table_name AND cl.relnamespace = n.oid
             LEFT JOIN pg_description d ON d.objoid = cl.oid AND d.objsubid = c.ordinal_position
-            WHERE c.table_schema = %s AND c.table_name = %s
+            WHERE c.table_schema = %s
             """
 
-            # 參數列表
-            params = [schema_name, table_name]
+            params: list = [schema_name]
+            if table_name is not None:
+                base_sql += " AND c.table_name = %s"
+                params.append(table_name)
 
             # 加入關鍵字搜尋條件（OR 邏輯）
             keyword_conditions = []
@@ -739,7 +762,8 @@ line suggesting /redshift-cache-schema --refresh.
                 params.append(f"%{kw}%")
 
             base_sql += " AND (" + " OR ".join(keyword_conditions) + ")"
-            base_sql += " ORDER BY c.ordinal_position;"
+            # schema-wide 模式按 table 名分組，再依 ordinal 排
+            base_sql += " ORDER BY c.table_name, c.ordinal_position;"
 
             with self.config.get_connection() as conn:
                 df = wr.redshift.read_sql_query(base_sql, con=conn, params=params)
@@ -750,6 +774,7 @@ line suggesting /redshift-cache-schema --refresh.
                     comment = r['column_comment'] if r['column_comment'] else "(No comment available)"
                     hit_count = calculate_hit_count(name, comment, keyword_list)
                     columns.append({
+                        "table_name": r['table_name'],
                         "column_name": name,
                         "data_type": r['data_type'],
                         "is_nullable": r['is_nullable'],
@@ -757,8 +782,8 @@ line suggesting /redshift-cache-schema --refresh.
                         "hit_count": hit_count
                     })
 
-            # 依 hit_count DESC, column_name ASC 排序
-            columns.sort(key=lambda x: (-x["hit_count"], x["column_name"]))
+            # 依 hit_count DESC, table_name ASC, column_name ASC 排序
+            columns.sort(key=lambda x: (-x["hit_count"], x["table_name"], x["column_name"]))
 
             # 分頁處理
             page = paginate_results(columns, limit, offset, DEFAULT_MAX_ITEMS)
@@ -770,6 +795,7 @@ line suggesting /redshift-cache-schema --refresh.
                 "keywords": keyword_list,
                 "schema_name": schema_name,
                 "table_name": table_name,
+                "scope": "single_table" if table_name is not None else "schema_wide",
                 "total_count": page["total_count"],
                 "returned_count": page["returned_count"],
                 "offset": page["offset"],

--- a/tests/test_skill_bodies.py
+++ b/tests/test_skill_bodies.py
@@ -302,3 +302,143 @@ def test_switch_profile_does_not_reference_password_collection():
         f"redshift-switch-profile leaked password-collection tokens: {leaks}. "
         f"The skill assumes the target profile already has a password in keychain."
     )
+
+
+# ===== skill body ↔ MCP signature drift =====
+#
+# The grep skills' Step 1b shows MCP tool calls inline (e.g.
+# `search_columns(keywords, schema_name=<schema>, table_name=None)`). If the
+# MCP signature changes (a kwarg renamed, removed) the skill body silently
+# drifts. These tests parse the skill prose for tool-call patterns and check
+# every kwarg against the actual function definition in redshift_tools.py via
+# AST — no instantiation, no DB.
+
+import ast
+
+REDSHIFT_TOOLS_PY = REPO_ROOT / "src" / "redshift_comment_mcp" / "redshift_tools.py"
+GREP_COLUMNS_SKILL = SKILLS_DIR / "redshift-grep-columns" / "SKILL.md"
+GREP_TABLES_SKILL = SKILLS_DIR / "redshift-grep-tables" / "SKILL.md"
+
+
+def _mcp_tool_param_names(fn_name: str) -> set[str]:
+    """Return the parameter names of a function defined inside redshift_tools.py.
+
+    Walks the AST to find the nested function (registered MCP tools live
+    inside _setup_tools) and pulls its argument names. No instantiation.
+    """
+    tree = ast.parse(REDSHIFT_TOOLS_PY.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == fn_name:
+            args = node.args
+            return {a.arg for a in (*args.args, *args.kwonlyargs)}
+    raise AssertionError(f"function {fn_name!r} not found in {REDSHIFT_TOOLS_PY.name}")
+
+
+_CALL_NAME_PARAM = re.compile(
+    # Match `\b(name)\(` then capture the balanced argument list.
+    # This is intentionally simple — we don't try to parse Python; we just
+    # extract the (...) span by walking parens, then scan for `kwarg=` patterns.
+    r"\b(search_columns|search_tables)\("
+)
+# Match `kwarg = ...` patterns inside an argument list. Excludes `==` and
+# excludes patterns that look like comparisons (`x == y`).
+_KWARG = re.compile(r"\b(\w+)\s*=(?!=)")
+
+
+def _extract_calls(body: str, fn_name: str) -> list[str]:
+    """Yield the inner argument-text of every `fn_name(...)` call in body."""
+    out: list[str] = []
+    for m in re.finditer(rf"\b{re.escape(fn_name)}\(", body):
+        depth = 1
+        i = m.end()
+        n = len(body)
+        while i < n and depth > 0:
+            c = body[i]
+            if c == "(":
+                depth += 1
+            elif c == ")":
+                depth -= 1
+                if depth == 0:
+                    out.append(body[m.end():i])
+                    break
+            i += 1
+    return out
+
+
+@pytest.mark.parametrize(
+    "skill_path,fn_name",
+    [
+        (GREP_COLUMNS_SKILL, "search_columns"),
+        (GREP_TABLES_SKILL, "search_tables"),
+    ],
+    ids=["grep-columns→search_columns", "grep-tables→search_tables"],
+)
+def test_grep_skill_calls_match_mcp_signature(skill_path, fn_name):
+    """Every kwarg the skill body uses on `fn_name(...)` must exist on the
+    actual MCP tool's signature.
+
+    Catches drift like: MCP renames `table_name` to `relation_name` and
+    forgets to update the skill body — the next LLM invocation would pass
+    a non-existent kwarg and crash.
+    """
+    body = skill_path.read_text()
+    actual_params = _mcp_tool_param_names(fn_name)
+
+    calls = _extract_calls(body, fn_name)
+    assert calls, (
+        f"{skill_path.parent.name}: SKILL.md mentions no `{fn_name}(...)` "
+        f"calls — Step 1b documentation likely drifted"
+    )
+
+    for call_text in calls:
+        used_kwargs = set(_KWARG.findall(call_text))
+        unknown = used_kwargs - actual_params
+        assert not unknown, (
+            f"{skill_path.parent.name} body uses {fn_name}({sorted(used_kwargs)}); "
+            f"unknown kwargs {sorted(unknown)} not in actual signature "
+            f"{sorted(actual_params)}. Update SKILL.md or revert the rename."
+        )
+
+
+# ===== bash block syntactic validity =====
+#
+# The grep skills teach the LLM concrete bash recipes (cache lookup, grep,
+# awk filter). A typo in the skill body would propagate into every LLM
+# invocation. `bash -n` does a syntax check without executing — cheap, runs
+# in CI, and catches the obvious `bash` style bugs.
+
+import subprocess
+
+_BASH_FENCE = re.compile(r"```bash\n(.*?)\n```", re.DOTALL)
+
+
+@pytest.mark.parametrize(
+    "skill_path",
+    [GREP_COLUMNS_SKILL, GREP_TABLES_SKILL],
+    ids=["grep-columns", "grep-tables"],
+)
+def test_grep_skill_bash_blocks_parse(skill_path):
+    """Every ```bash``` fence in the grep skills must pass `bash -n`.
+
+    Placeholders like `'KEYWORD'` / `"SCHEMA"` are valid bash literals —
+    the syntax check passes without needing concrete values.
+    """
+    text = skill_path.read_text()
+    blocks = _BASH_FENCE.findall(text)
+    assert blocks, (
+        f"{skill_path.parent.name}: no ```bash``` fenced blocks found — "
+        f"the skill's cache-path recipe must be present"
+    )
+    for i, src in enumerate(blocks):
+        result = subprocess.run(
+            ["bash", "-n"],
+            input=src,
+            text=True,
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            pytest.fail(
+                f"{skill_path.parent.name} bash block #{i} fails `bash -n`:\n"
+                f"  stderr: {result.stderr.strip()}\n"
+                f"  source:\n{src}"
+            )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -603,6 +603,7 @@ class TestSearchTools:
         config, mock_conn = mock_config
 
         mock_df = pd.DataFrame({
+            'table_name': ['orders', 'orders', 'orders'],
             'column_name': ['total_amount', 'order_id', 'amount'],
             'data_type': ['numeric', 'integer', 'numeric'],
             'is_nullable': ['YES', 'NO', 'YES'],
@@ -669,6 +670,7 @@ class TestSearchTools:
         config, mock_conn = mock_config
 
         mock_df = pd.DataFrame({
+            'table_name': ['orders', 'orders'],
             'column_name': ['customer_id', 'customer_name'],
             'data_type': ['integer', 'varchar'],
             'is_nullable': ['NO', 'YES'],
@@ -1164,3 +1166,141 @@ class TestSingleGetterDoesNotTruncate:
 
         assert result["comment"] == long_comment
         assert "…" not in result["comment"]
+
+
+# ========== Cross-scope search behavior (schema_name / table_name optional) ==========
+
+class TestSearchToolsCrossScope:
+    """search_tables / search_columns now accept None for the narrowing arg
+    to enable cluster-wide / schema-wide searches respectively."""
+
+    @patch('awswrangler.redshift.read_sql_query')
+    def test_search_tables_cross_schema(self, mock_read_sql, mock_config):
+        """search_tables(schema_name=None) should search across all schemas."""
+        config, _ = mock_config
+
+        mock_df = pd.DataFrame({
+            'schema_name': ['dbt_marts', 'raw_events', 'dbt_staging'],
+            'table_name': ['fct_orders', 'orders_raw', 'stg_orders'],
+            'table_type': ['BASE TABLE', 'BASE TABLE', 'BASE TABLE'],
+            'table_comment': ['Order facts', 'Raw orders', 'Staged orders'],
+        })
+        mock_read_sql.return_value = mock_df
+
+        tools = RedshiftTools(config)
+        search_tables = _get_tool_fn(tools, 'search_tables')
+
+        # No schema_name argument
+        result = search_tables(keywords='order')
+
+        assert result["schema_filter"] is None
+        assert result["total_count"] == 3
+        # Verify rows from multiple schemas come back together
+        schemas_seen = {row["schema_name"] for row in result["tables"]}
+        assert schemas_seen == {"dbt_marts", "raw_events", "dbt_staging"}
+
+    @patch('awswrangler.redshift.read_sql_query')
+    def test_search_tables_explicit_schema_still_works(self, mock_read_sql, mock_config):
+        """Backward compat: passing schema_name still scopes to that schema."""
+        config, _ = mock_config
+
+        mock_df = pd.DataFrame({
+            'schema_name': ['sales'],
+            'table_name': ['orders'],
+            'table_type': ['BASE TABLE'],
+            'table_comment': ['Orders'],
+        })
+        mock_read_sql.return_value = mock_df
+
+        tools = RedshiftTools(config)
+        search_tables = _get_tool_fn(tools, 'search_tables')
+
+        result = search_tables(keywords='order', schema_name='sales')
+
+        assert result["schema_filter"] == 'sales'
+        assert result["total_count"] == 1
+
+    def test_search_tables_invalid_schema_when_provided(self, mock_config):
+        """Invalid schema_name still raises (only the None case is permitted to skip filter)."""
+        config, _ = mock_config
+        tools = RedshiftTools(config)
+        search_tables = _get_tool_fn(tools, 'search_tables')
+
+        with pytest.raises(ValueError, match="Invalid schema name"):
+            search_tables(keywords='order', schema_name='bad-name')
+
+    @patch('awswrangler.redshift.read_sql_query')
+    def test_search_columns_schema_wide(self, mock_read_sql, mock_config):
+        """search_columns(table_name=None) should search every table in the schema
+        and emit table_name on each row."""
+        config, _ = mock_config
+
+        # Cross-table hits — multiple tables share the keyword in schema "dbt_marts"
+        mock_df = pd.DataFrame({
+            'table_name': ['fct_orders', 'fct_returns', 'dim_users'],
+            'column_name': ['customer_id', 'customer_id', 'id'],
+            'data_type': ['bigint', 'bigint', 'bigint'],
+            'is_nullable': ['NO', 'NO', 'NO'],
+            'column_comment': [
+                'Customer reference (FK to dim_users.id)',
+                'Customer who initiated the return',
+                'Customer primary key',
+            ],
+        })
+        mock_read_sql.return_value = mock_df
+
+        tools = RedshiftTools(config)
+        search_columns = _get_tool_fn(tools, 'search_columns')
+
+        # Omit table_name: schema-wide search
+        result = search_columns(keywords='customer', schema_name='dbt_marts')
+
+        assert result["schema_name"] == 'dbt_marts'
+        assert result["table_name"] is None
+        assert result["scope"] == 'schema_wide'
+        assert result["total_count"] == 3
+        # Verify table_name is emitted per row (the natural primitive for cross-table)
+        tables_seen = {row["table_name"] for row in result["columns"]}
+        assert tables_seen == {"fct_orders", "fct_returns", "dim_users"}
+
+    @patch('awswrangler.redshift.read_sql_query')
+    def test_search_columns_single_table_scope_label(self, mock_read_sql, mock_config):
+        """Backward compat: passing table_name still works and scope is single_table."""
+        config, _ = mock_config
+
+        mock_df = pd.DataFrame({
+            'table_name': ['orders'],
+            'column_name': ['customer_id'],
+            'data_type': ['bigint'],
+            'is_nullable': ['NO'],
+            'column_comment': ['Customer FK'],
+        })
+        mock_read_sql.return_value = mock_df
+
+        tools = RedshiftTools(config)
+        search_columns = _get_tool_fn(tools, 'search_columns')
+
+        result = search_columns(keywords='customer', schema_name='sales', table_name='orders')
+
+        assert result["schema_name"] == 'sales'
+        assert result["table_name"] == 'orders'
+        assert result["scope"] == 'single_table'
+
+    def test_search_columns_invalid_table_when_provided(self, mock_config):
+        """Invalid table_name still raises (only the None case skips the filter)."""
+        config, _ = mock_config
+        tools = RedshiftTools(config)
+        search_columns = _get_tool_fn(tools, 'search_columns')
+
+        with pytest.raises(ValueError, match="Invalid table name"):
+            search_columns(keywords='customer', schema_name='sales', table_name='bad-table')
+
+    def test_search_columns_schema_still_required(self, mock_config):
+        """schema_name remains required even though table_name is now optional —
+        cluster-wide column search would be too expensive on the leader node."""
+        config, _ = mock_config
+        tools = RedshiftTools(config)
+        search_columns = _get_tool_fn(tools, 'search_columns')
+
+        with pytest.raises(ValueError, match="Invalid schema name"):
+            search_columns(keywords='customer', schema_name='bad-schema')


### PR DESCRIPTION
## Summary

Adds cross-scope search at two layers — skill (cache-first, the typical path) and MCP tool (live fallback when cache is stale). Originally just the skills; expanded after empirical benchmarking showed the legacy live-fallback was effectively unusable.

### Two new skills

- **`/redshift-grep-columns`** — find every column whose name or comment matches a keyword across all tables in one (or all) schemas. Pre-JOIN reconnaissance, naming-consistency audit.
- **`/redshift-grep-tables`** — find every table whose name or comment matches a keyword across all schemas. Topic search when schema is unknown.

### MCP tool extension (commit 2)

Promote the narrowing arg on the existing `search_tables` / `search_columns` tools to optional:

| Before | After |
|---|---|
| `search_tables(keywords, schema_name)` — required | `search_tables(keywords, schema_name=None)` |
| `search_columns(keywords, schema_name, table_name)` — both required | `search_columns(keywords, schema_name, table_name=None)` |

`search_columns` now returns `table_name` on each row (always, including single-table calls — additive, backward compatible).

`schema_name` on `search_columns` remains required — making both None would mean cluster-wide column search (~120K leader-node rows), a known pathology.

## Architecture

```
Cache fresh → bash grep on local TSV (~50ms) ✅ best path
Cache stale → MCP tool, single SQL (~700ms columns / ~175ms tables) ✅ acceptable fallback
              ─ replaces legacy "orchestrate many search_* calls" approach (~19s)
```

## Live-cluster benchmarks

Keyword `id` on the 12K-col `dbt_dev_kouko` schema (largest in user's cluster):

| Path | Latency | vs old fallback |
|---|---|---|
| Skill cache hit (bash grep) | ~50 ms | — |
| **New MCP tool fallback** (single SQL) | **~700 ms** | **27x faster** |
| Old orchestration fallback (legacy) | ~19,000 ms | baseline |

Cluster-wide `search_tables`: ~175ms for 254 hits. Single SQL across `pg_class` + `pg_description` is well-optimized by Redshift's leader.

## Files

**Commit 1 — skills (5438e4e):**
- 2 new skill packages under `skills/redshift-grep-columns/` and `skills/redshift-grep-tables/` (SKILL.md + tri-lingual READMEs each)
- 2 new slash commands under `commands/`
- See-also cross-links added to `/redshift-explore` and `/redshift-cache-schema`
- Skill list rows added to root `README.md` / `README.ja.md` / `README.zh-TW.md` and `skills/README.md`

**Commit 2 — MCP tool extension + skill body update (f0bc9ff):**
- `src/redshift_comment_mcp/redshift_tools.py`: optional schema_name on search_tables, optional table_name on search_columns, server-level instructions updated, search_columns returns table_name on each row
- `tests/test_tools.py`: 7 new tests for cross-scope behavior + 2 mock fixtures updated
- `skills/redshift-grep-columns/SKILL.md` Step 1b + Anti-patterns rewritten
- `skills/redshift-grep-tables/SKILL.md` Step 1b + Anti-patterns rewritten

## Test plan

- [x] All 242 tests pass (235 baseline + 7 cross-scope behavior tests)
- [x] All 14 parametrized invariant checks (frontmatter, third-person, README parity, no dead refs, etc.) pass for both new skills
- [x] Live-cluster benchmark verified the SQL shape and latency claims
- [x] Backward compat: existing search_tables(kw, schema) and search_columns(kw, schema, table) signatures still work
- [ ] Reviewer: smoke-test the new skill flows against a real cluster (cache fresh + cache stale)

## Notes on payload size

Cluster-wide `search_tables` and schema-wide `search_columns` can return larger payloads than their narrower predecessors — up to 50 rows × 3680 chars (max table comment in this cluster) ≈ 184KB worst case for tables; 50 × 471 ≈ 23KB for columns. This is mitigated by the `MAX_COMMENT_LEN=1000` cap landing in [#23](https://github.com/kouko/redshift-comment-mcp/pull/23). Until that merges, rely on `DEFAULT_MAX_ITEMS=50` row cap; in practice mean payload is ~10KB (verified empirically) so risk is low.

## Independent of #23

This branch was rebased onto main and does not depend on #23 (cap + scale_hint). Both PRs touch different code regions and should merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)