### PR TITLE
feat(execute_sql): user-facing SQL transparency on execute_sql

### DIFF
--- a/src/redshift_comment_mcp/redshift_tools.py
+++ b/src/redshift_comment_mcp/redshift_tools.py
@@ -300,6 +300,15 @@ SEARCH SCOPE:
 
 For ad-hoc exploration, prefer list_* / search_* tools over execute_sql
 against information_schema — they include comments directly.
+
+EXECUTE_SQL TRANSPARENCY: When you call execute_sql, the response
+includes `_executed_sql` (the SQL that ran) and `_user_facing_message`
+(a display directive). You MUST surface `_executed_sql` verbatim to
+the user — in a code block, before or alongside the result. Do not
+paraphrase, summarize, or hide the query. Users need direct visibility
+into what runs against their database. The metadata tools (list_* /
+search_* / get_*) use fixed catalog templates and do not carry these
+fields; their semantic API is the contract.
 """
         )
         self._setup_tools()
@@ -963,7 +972,14 @@ against information_schema — they include comments directly.
                     "offset": page["offset"],
                     "has_more": page["has_more"],
                     "columns": columns,
-                    "data": page["items"]
+                    "data": page["items"],
+                    "_executed_sql": [sql_statement],
+                    "_user_facing_message": (
+                        "Show the user the SQL from _executed_sql verbatim "
+                        "(in a code block) before presenting these results. "
+                        "Do not paraphrase or omit it — users need direct "
+                        "visibility into what runs against their database."
+                    ),
                 }
 
                 if page["auto_truncated"]:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,46 @@
+"""E2E gate — pytest opt-in mirroring tests/integration/.
+
+These tests spawn the MCP server as a stdio subprocess and exercise the
+full MCP JSON-RPC wire protocol against a real Redshift cluster, so they
+share the same prerequisites as the integration tests: an active profile
+and a password in keyring. The opt-in env var is the same one
+(`REDSHIFT_INTEGRATION=1`) so a single deliberate flip enables both.
+
+Why a separate folder: integration tests call `tool.fn` directly to keep
+each pytest under 200ms. E2E tests pay the subprocess-spawn cost (~1s)
+to validate the wire format itself — they catch serialization bugs and
+`instructions` handshake regressions that in-process tests cannot.
+
+To opt in:
+
+    REDSHIFT_INTEGRATION=1 uv run pytest tests/e2e/
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from redshift_comment_mcp.config import get_password, read_active_profile, read_profile
+
+OPT_IN_ENV = "REDSHIFT_INTEGRATION"
+
+
+@pytest.fixture(scope="module")
+def e2e_preconditions_satisfied():
+    """Skips the whole module unless the opt-in env var is set AND a profile
+    with a keychain password is configured. No return value — the fixture's
+    presence on a test is the gate."""
+    if os.environ.get(OPT_IN_ENV) != "1":
+        pytest.skip(
+            f"E2E tests require {OPT_IN_ENV}=1 to opt in. "
+            f"Run with `{OPT_IN_ENV}=1 uv run pytest tests/e2e/`."
+        )
+
+    profile_name = read_active_profile() or "default"
+    profile = read_profile(profile_name)
+    if profile is None:
+        pytest.skip(f"No '{profile_name}' profile in config.toml — run /redshift-setup.")
+
+    if get_password(profile_name) is None:
+        pytest.skip(f"No password in keyring for '{profile_name}' — run set-password.")

--- a/tests/e2e/test_executed_sql_wire.py
+++ b/tests/e2e/test_executed_sql_wire.py
@@ -1,0 +1,147 @@
+"""End-to-end test of _executed_sql / _user_facing_message via real MCP wire.
+
+What's exercised here that in-process and integration tests cannot reach:
+
+  - The MCP JSON-RPC handshake: server `instructions` correctly served
+  - Cross-process serialization of the new fields through stdio transport
+  - The actual deployment shape (subprocess spawn, same as MCP clients use)
+
+Each test spawns one stdio subprocess running the redshift-comment-mcp
+server entrypoint. Wall-clock cost ~2-3s per test — much heavier than the
+in-process tests, so the module is kept small and focused on contract
+shape (not behavior breadth — that's the integration suite's job).
+
+Assertion-leak discipline: on assertion failure pytest dumps the
+expression's local variables, which includes raw server payloads. To keep
+real schema / table names off CI logs and screenshots:
+
+  - Custom assertion messages NEVER format the full payload — they cite
+    keys / lengths / presence only.
+  - Variables holding metadata payloads are scoped tightly and not bound
+    to names that pytest displays as "interesting" (avoid `payload =`
+    at module/class scope).
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import pytest  # noqa: F401  — fixture symbol comes from conftest
+from fastmcp import Client
+from fastmcp.client.transports import StdioTransport
+
+MUST_INCLUDE_IN_INSTRUCTIONS = "EXECUTE_SQL TRANSPARENCY"
+
+
+def _spawn_transport() -> StdioTransport:
+    """Spawn the server as a Python subprocess via the same import path the
+    pyproject.toml console-script entry uses."""
+    return StdioTransport(
+        command=sys.executable,
+        args=["-c", "from redshift_comment_mcp.server import main; main()"],
+    )
+
+
+def _structured(resp) -> dict:
+    """FastMCP client response carries the tool's dict under either `.data`
+    or `.structured_content` depending on version. Coerce both to a plain
+    dict so tests can use ordinary indexing."""
+    return getattr(resp, "data", None) or getattr(resp, "structured_content", None)
+
+
+async def _run_instructions_handshake_carries_transparency_block():
+    """The MCP capability handshake's `instructions` field must include the
+    EXECUTE_SQL TRANSPARENCY directive — agents read this once at session
+    init, so a missing block silently disables the user-disclosure contract."""
+    async with Client(_spawn_transport()) as client:
+        init = client.initialize_result
+        instructions = (init.instructions or "") if init else ""
+        # Citing the marker, not the full block — keeps failure dump clean.
+        assert MUST_INCLUDE_IN_INSTRUCTIONS in instructions, (
+            f"server instructions missing {MUST_INCLUDE_IN_INSTRUCTIONS!r} "
+            f"(length={len(instructions)})"
+        )
+
+
+async def _run_tools_list_registers_execute_sql_via_wire():
+    """Round-trips through `tools/list` and confirms execute_sql is on the
+    wire — defends against accidentally un-registering it during refactor."""
+    async with Client(_spawn_transport()) as client:
+        tools = await client.list_tools()
+        names = {t.name for t in tools}
+        assert "execute_sql" in names, f"execute_sql missing (got {len(names)} tools)"
+
+
+async def _run_execute_sql_round_trip_carries_transparency_fields():
+    """Wire-level proof that _executed_sql + _user_facing_message survive the
+    FastMCP serialization layer and reach the client intact."""
+    sql = "SELECT 1 AS x"
+    async with Client(_spawn_transport()) as client:
+        body = _structured(await client.call_tool("execute_sql", {"sql_statement": sql}))
+        assert body is not None, "execute_sql response had no structured payload"
+        # _executed_sql must echo the verbatim input.
+        assert body.get("_executed_sql") == [sql], (
+            f"_executed_sql wrong shape "
+            f"(present={'_executed_sql' in body}, "
+            f"type={type(body.get('_executed_sql')).__name__})"
+        )
+        msg = body.get("_user_facing_message", "")
+        assert "_executed_sql" in msg, (
+            f"_user_facing_message lacks field-name reference (length={len(msg)})"
+        )
+        assert "verbatim" in msg.lower() or "do not" in msg.lower(), (
+            f"_user_facing_message lacks directive language (length={len(msg)})"
+        )
+
+
+async def _run_metadata_tool_wire_response_omits_transparency_fields():
+    """Scope guard: list_schemas must NOT carry _executed_sql /
+    _user_facing_message over the wire. Metadata tools use fixed catalog
+    templates whose SQL is implementation detail; pushing them to users is
+    noise, not signal. This test catches accidental scope creep at the
+    serialization boundary.
+
+    Leak discipline: only assert key absence + result-list length. Do NOT
+    print the response, do NOT include the response in the assertion
+    message — schema names live in there.
+    """
+    async with Client(_spawn_transport()) as client:
+        body = _structured(
+            await client.call_tool(
+                "list_schemas", {"limit": 2, "include_comments": False}
+            )
+        )
+        assert body is not None, "list_schemas response had no structured payload"
+        assert "_executed_sql" not in body, (
+            "scope creep: list_schemas leaked _executed_sql over the wire"
+        )
+        assert "_user_facing_message" not in body, (
+            "scope creep: list_schemas leaked _user_facing_message over the wire"
+        )
+        # Sanity that the call really hit the cluster (not a wire-only short-
+        # circuit). Length only — no schema names.
+        assert isinstance(body.get("schemas"), list), "schemas field missing or wrong type"
+
+
+# ===== sync pytest entry points =====
+#
+# The project doesn't depend on pytest-asyncio; the test runner sees only
+# these sync wrappers and runs the async work via asyncio.run. Each wrapper
+# also pulls the conftest fixture, so the opt-in skip applies before the
+# subprocess is spawned (saves ~1s on a skipped run).
+
+
+def test_instructions_handshake_carries_transparency_block(e2e_preconditions_satisfied):
+    asyncio.run(_run_instructions_handshake_carries_transparency_block())
+
+
+def test_tools_list_registers_execute_sql_via_wire(e2e_preconditions_satisfied):
+    asyncio.run(_run_tools_list_registers_execute_sql_via_wire())
+
+
+def test_execute_sql_round_trip_carries_transparency_fields(e2e_preconditions_satisfied):
+    asyncio.run(_run_execute_sql_round_trip_carries_transparency_fields())
+
+
+def test_metadata_tool_wire_response_omits_transparency_fields(e2e_preconditions_satisfied):
+    asyncio.run(_run_metadata_tool_wire_response_omits_transparency_fields())

--- a/tests/integration/test_live_cluster_smoke.py
+++ b/tests/integration/test_live_cluster_smoke.py
@@ -418,3 +418,16 @@ def test_list_columns_offset(live_redshift_tools, live_target):
     )
     assert shifted["columns"][0]["name"] != full["columns"][0]["name"]
     assert shifted["offset"] == 1
+
+
+# ===== execute_sql user-transparency =====
+
+
+def test_execute_sql_carries_transparency_fields_on_real_response(live_redshift_tools):
+    """Smoke: the live execute_sql round-trip carries both _executed_sql
+    (verbatim user SQL) and _user_facing_message (display directive)."""
+    execute_sql = _get_tool_fn(live_redshift_tools, "execute_sql")
+    result = execute_sql(sql_statement="SELECT 1 AS x")
+    assert result["_executed_sql"] == ["SELECT 1 AS x"]
+    assert "_user_facing_message" in result
+    assert "_executed_sql" in result["_user_facing_message"]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1303,3 +1303,95 @@ class TestSearchToolsCrossScope:
 
         with pytest.raises(ValueError, match="Invalid schema name"):
             search_columns(keywords='customer', schema_name='bad-schema')
+
+
+class TestExecuteSqlTransparency:
+    """execute_sql echoes the user's SQL plus a user-facing display directive.
+
+    Scope rationale: only execute_sql runs unbounded LLM-generated SQL; the
+    metadata tools use fixed catalog templates whose SQL is implementation
+    detail, not user-actionable. Forcing display of those would be noise.
+    Hence transparency fields live ONLY on execute_sql.
+    """
+
+    @patch('awswrangler.redshift.read_sql_query')
+    def test_execute_sql_returns_executed_sql_field(self, mock_read_sql, mock_config):
+        config, _ = mock_config
+        mock_read_sql.return_value = pd.DataFrame({'x': [1]})
+
+        tools = RedshiftTools(config)
+        execute_sql = _get_tool_fn(tools, 'execute_sql')
+        result = execute_sql(sql_statement="SELECT 1 AS x")
+
+        assert "_executed_sql" in result
+        assert result["_executed_sql"] == ["SELECT 1 AS x"]
+
+    @patch('awswrangler.redshift.read_sql_query')
+    def test_execute_sql_returns_user_facing_message(self, mock_read_sql, mock_config):
+        """Message must clearly direct the agent to surface the SQL to the user."""
+        config, _ = mock_config
+        mock_read_sql.return_value = pd.DataFrame({'x': [1]})
+
+        tools = RedshiftTools(config)
+        execute_sql = _get_tool_fn(tools, 'execute_sql')
+        result = execute_sql(sql_statement="SELECT 1 AS x")
+
+        assert "_user_facing_message" in result
+        msg = result["_user_facing_message"]
+        # Must reference the field name (so the agent knows what to display)
+        assert "_executed_sql" in msg
+        # Must use directive language; "verbatim" / "do not" pin the no-paraphrase
+        # contract more than just "show". Either signal is enough.
+        msg_lower = msg.lower()
+        assert "verbatim" in msg_lower or "do not" in msg_lower
+
+    @patch('awswrangler.redshift.read_sql_query')
+    def test_execute_sql_preserves_existing_fields(self, mock_read_sql, mock_config):
+        """Adding transparency fields must not displace columns / data / paging info."""
+        config, _ = mock_config
+        mock_read_sql.return_value = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
+
+        tools = RedshiftTools(config)
+        execute_sql = _get_tool_fn(tools, 'execute_sql')
+        result = execute_sql(sql_statement="SELECT a, b FROM t")
+
+        for key in ("total_count", "returned_count", "offset",
+                    "has_more", "columns", "data"):
+            assert key in result, f"existing field {key!r} disappeared"
+        assert result["columns"] == ["a", "b"]
+        assert result["total_count"] == 2
+
+    @patch('awswrangler.redshift.read_sql_query')
+    def test_metadata_tools_do_not_carry_transparency_fields(self, mock_read_sql, mock_config):
+        """Negative test pinning the scope decision: metadata tools must NOT
+        return _executed_sql / _user_facing_message. The catalog SQL is
+        implementation detail; surfacing it to users is noise, not signal.
+        Pin one tool from each category as a regression guard against scope creep."""
+        config, _ = mock_config
+        mock_read_sql.return_value = pd.DataFrame({
+            'schema_name': ['public'], 'schema_comment': [None],
+        })
+
+        tools = RedshiftTools(config)
+        list_schemas = _get_tool_fn(tools, 'list_schemas')
+        search_schemas = _get_tool_fn(tools, 'search_schemas')
+        get_schema_comment = _get_tool_fn(tools, 'get_schema_comment')
+
+        # list_*
+        r = list_schemas(include_comments=True)
+        assert "_executed_sql" not in r
+        assert "_user_facing_message" not in r
+
+        # search_* (different mock shape)
+        mock_read_sql.return_value = pd.DataFrame({
+            'schema_name': [], 'schema_comment': [],
+        })
+        r = search_schemas(keywords="any")
+        assert "_executed_sql" not in r
+        assert "_user_facing_message" not in r
+
+        # get_*
+        mock_read_sql.return_value = pd.DataFrame({'schema_comment': ['c']})
+        r = get_schema_comment(schema_name="public")
+        assert "_executed_sql" not in r
+        assert "_user_facing_message" not in r


### PR DESCRIPTION
## Summary

When agents call `execute_sql` against this MCP server, they often present the result to the user without showing the SQL that actually ran. Users have no visibility into what hit their Redshift cluster.

This PR adds **post-execution, user-facing** SQL transparency to `execute_sql` (only), with three reinforcing levers:

- `_executed_sql: [sql_statement]` in the response — verbatim user input, list-of-strings for shape parity with potential future multi-SQL tools
- `_user_facing_message` — a short directive telling the agent to display `_executed_sql` verbatim in a code block before/with results
- Server `instructions` adds an **EXECUTE_SQL TRANSPARENCY** block that mandates the display behaviour at handshake time

## Sample response

```jsonc
{
  "total_count": 1,
  "columns": ["x"],
  "data": [{"x": 1}],
  "_executed_sql": ["SELECT 1 AS x"],
  "_user_facing_message": "Show the user the SQL from _executed_sql verbatim (in a code block) before presenting these results. Do not paraphrase or omit it — users need direct visibility into what runs against their database."
}
```

## Scope decision: `execute_sql` only

Considered and rejected: applying the same transparency to the 10 metadata tools (`list_*` / `search_*` / `get_*`). Those tools use fixed catalog templates whose SQL is implementation detail, not user-actionable. Forcing display would be user-noise, not user-transparency. A negative test in each tier pins this scope so future scope creep is caught.

## Three-tier test coverage

| Tier | Location | Opt-in | Tests | What it catches |
|---|---|---|---|---|
| Unit | `tests/test_tools.py::TestExecuteSqlTransparency` | always | 4 | field shape, message language, scope guard |
| Integration | `tests/integration/test_live_cluster_smoke.py` | `REDSHIFT_INTEGRATION=1` | +1 | both fields survive a real Redshift round-trip |
| E2E | `tests/e2e/test_executed_sql_wire.py` | `REDSHIFT_INTEGRATION=1` | 4 | the MCP JSON-RPC wire protocol — handshake `instructions`, tools/list, cross-process serialization, wire-boundary scope guard |

E2E spawns the server as a stdio subprocess (the actual deployment shape) and uses `fastmcp.Client` to exchange real MCP messages.

**Leak discipline (E2E):** failure messages only cite key presence / type / length — never the raw payload. Real schema names from `list_schemas` responses never reach pytest's failure dump.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/integration --ignore=tests/e2e` — 248 passed, 2 skipped
- [x] `REDSHIFT_INTEGRATION=1 uv run pytest tests/integration/` — 22 passed, 1 skipped
- [x] `REDSHIFT_INTEGRATION=1 uv run pytest tests/e2e/` — 4 passed
- [x] `uv run pytest tests/e2e/` (no opt-in) — 4 skipped cleanly in 200ms (no subprocess spawn)
- [x] Live wire-level inspection: instructions handshake carries EXECUTE_SQL TRANSPARENCY; execute_sql payload carries both new fields; list_schemas payload does not

## Reversibility

Purely additive — existing callers ignoring the two new fields are unaffected. No protocol change, no new tool, no signature change. Revert is one commit.

## Out of scope

- **Pre-execution display / approval** — that's a Claude Code client feature (e.g. PreToolUse hook), not solvable from the MCP server side. A natural follow-up.
- **Transparency on metadata tools** — explicitly rejected; see Scope decision above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)