### PR TITLE
fix(config): single-profile fallback rescues post-upgrade breakage

### DIFF
--- a/src/redshift_comment_mcp/config.py
+++ b/src/redshift_comment_mcp/config.py
@@ -159,11 +159,35 @@ def resolve_active_profile(cli_profile: Optional[str] = None) -> str:
     """Resolve which profile the server should use.
 
     Priority: explicit CLI ``--profile`` flag > ``REDSHIFT_COMMENT_PROFILE``
-    env var > ``active-profile`` pointer file > ``"default"``.
+    env var > ``active-profile`` pointer file > implicit fallback.
+
+    Implicit fallback (when nothing was explicit):
+      1. ``"default"`` if it exists in config.toml — backward compatibility
+         for users whose single profile is named "default"
+      2. The lone profile if exactly one exists — **upgrade rescue** for
+         pre-3884f98 users who picked a non-"default" name at install
+      3. ``"default"`` as a literal — lets the server raise its existing
+         "Profile 'default' is not configured" error (improved by
+         server.py to surface available profiles + switch-profile skill)
+
+    Explicit inputs are returned as-is even when they don't resolve to a
+    real profile — the user told us what they want; let the downstream
+    raise a typo-friendly error.
     """
     if cli_profile:
         return cli_profile
     env = os.environ.get("REDSHIFT_COMMENT_PROFILE")
     if env:
         return env
-    return read_active_profile() or "default"
+    pointer = read_active_profile()
+    if pointer:
+        return pointer
+
+    # Implicit fallback path — touches config.toml because resolution now
+    # depends on what's actually configured, not just on a literal name.
+    profiles = read_all()
+    if "default" in profiles:
+        return "default"
+    if len(profiles) == 1:
+        return next(iter(profiles))
+    return "default"

--- a/src/redshift_comment_mcp/server.py
+++ b/src/redshift_comment_mcp/server.py
@@ -51,6 +51,20 @@ def resolve_connection_params(args: argparse.Namespace) -> tuple[str, int, str, 
     profile_name = cfg.resolve_active_profile(args.profile)
     profile = cfg.read_profile(profile_name)
     if not profile:
+        # Two distinct UX cases share this raise site:
+        # - No profiles at all → user needs to run /redshift-setup
+        # - ≥1 profile, just not the one we resolved → user needs to
+        #   switch (typo in name, or post-upgrade multi-profile with no
+        #   "default" and no pointer file). List them so the user can
+        #   spot the right name without re-running setup.
+        existing = cfg.list_profiles()
+        if existing:
+            raise ValueError(
+                f"Profile '{profile_name}' is not configured. "
+                f"Existing profiles: {', '.join(existing)}. "
+                f"Run /redshift-comment-mcp:redshift-switch-profile to pick one, "
+                f"or /redshift-comment-mcp:redshift-setup to add a new profile."
+            )
         raise ValueError(
             f"Profile '{profile_name}' is not configured. "
             f"Run /redshift-comment-mcp:redshift-setup in chat to set up "

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -214,3 +214,74 @@ def test_resolve_active_profile_empty_cli_arg_treated_as_unset(tmp_xdg, monkeypa
     """Empty CLI arg should not pin to "" — fall through to env var."""
     monkeypatch.setenv("REDSHIFT_COMMENT_PROFILE", "envname")
     assert config.resolve_active_profile("") == "envname"
+
+
+# ===== single-profile fallback (upgrade-rescue for PR #22) =====
+#
+# 3884f98 made single-profile users canonical with "absent pointer file =
+# use 'default'". That works only for users whose single profile happens
+# to be named "default". Pre-3884f98 setups picked the name at install
+# time, so anyone with a non-"default" name got hard-broken by the
+# upgrade. These tests pin the rescue: when the implicit fallback would
+# hit a missing "default" profile, but exactly one profile exists, use
+# that one. Multi-profile / zero-profile cases stay loud (server raises
+# its existing ValueError with improved guidance from server.py).
+
+
+def test_resolve_active_profile_falls_back_to_single_profile_when_no_default(
+    tmp_xdg, monkeypatch
+):
+    """Upgrade rescue: one profile, not named 'default', no pointer file,
+    no env, no CLI → use that one profile."""
+    monkeypatch.delenv("REDSHIFT_COMMENT_PROFILE", raising=False)
+    config.write_profile("ichef-prod", host="h", port=5439, user="u", dbname="d")
+    assert config.resolve_active_profile() == "ichef-prod"
+
+
+def test_resolve_active_profile_prefers_default_over_other_profiles(
+    tmp_xdg, monkeypatch
+):
+    """When 'default' exists alongside others, the implicit fallback must
+    still pick 'default' — backward compatibility for users who do use
+    that name."""
+    monkeypatch.delenv("REDSHIFT_COMMENT_PROFILE", raising=False)
+    config.write_profile("default", host="h1", port=5439, user="u", dbname="d")
+    config.write_profile("prod", host="h2", port=5439, user="u", dbname="d")
+    assert config.resolve_active_profile() == "default"
+
+
+def test_resolve_active_profile_returns_default_when_multiple_profiles_no_default(
+    tmp_xdg, monkeypatch
+):
+    """Ambiguous case: 2+ profiles, none 'default', no pointer file.
+    Return 'default' so the server raises a clear error pointing at
+    /redshift-switch-profile — do NOT silently pick one of them."""
+    monkeypatch.delenv("REDSHIFT_COMMENT_PROFILE", raising=False)
+    config.write_profile("prod", host="h1", port=5439, user="u", dbname="d")
+    config.write_profile("staging", host="h2", port=5439, user="u", dbname="d")
+    # Returns literal "default" — server.read_profile("default") then fails
+    # cleanly, which triggers the improved error message tested in
+    # test_server_resolution.py.
+    assert config.resolve_active_profile() == "default"
+
+
+def test_resolve_active_profile_returns_default_when_no_profiles_at_all(
+    tmp_xdg, monkeypatch
+):
+    """Fresh install / empty config.toml: nothing to rescue with, return
+    'default' so server raises the 'run /redshift-setup' error."""
+    monkeypatch.delenv("REDSHIFT_COMMENT_PROFILE", raising=False)
+    assert config.resolve_active_profile() == "default"
+
+
+def test_resolve_active_profile_pointer_file_overrides_single_profile_fallback(
+    tmp_xdg, monkeypatch
+):
+    """If user explicitly set a pointer file, honor it even if it names a
+    non-existent profile — explicit beats implicit, lets server raise a
+    'pointer references missing profile' style error rather than silently
+    redirecting to the single existing profile."""
+    monkeypatch.delenv("REDSHIFT_COMMENT_PROFILE", raising=False)
+    config.write_profile("ichef-prod", host="h", port=5439, user="u", dbname="d")
+    config.write_active_profile("ghost-profile")
+    assert config.resolve_active_profile() == "ghost-profile"

--- a/tests/test_server_resolution.py
+++ b/tests/test_server_resolution.py
@@ -195,3 +195,73 @@ def test_profile_exists_but_no_password_error_offers_two_paths(tmp_xdg, fake_key
     assert "/redshift-comment-mcp:redshift-setup" in msg
     assert "set-password" in msg
     assert "default" in msg
+
+
+# ===== upgrade rescue: single non-"default" profile works end-to-end =====
+
+
+def test_profile_mode_single_non_default_profile_auto_resolves(
+    tmp_xdg, fake_keyring, monkeypatch
+):
+    """End-to-end upgrade rescue: a fresh machine has one profile named
+    'ichef-prod' (not 'default') and no active-profile pointer file. The
+    server must auto-pick that profile and connect — no error, no manual
+    setup step required."""
+    monkeypatch.delenv("REDSHIFT_COMMENT_PROFILE", raising=False)
+    config.write_profile(
+        "ichef-prod",
+        host="ichef-prod.example.com", port=5439, user="alice", dbname="warehouse",
+    )
+    config.set_password("ichef-prod", "ichef-pw")
+    args = _ns()
+    host, port, user, password, dbname = server.resolve_connection_params(args)
+    assert (host, port, user, password, dbname) == (
+        "ichef-prod.example.com", 5439, "alice", "ichef-pw", "warehouse",
+    )
+
+
+# ===== error message clarity when no rescue is possible =====
+
+
+def test_ambiguous_multi_profile_error_lists_profiles_and_suggests_switch(
+    tmp_xdg, fake_keyring, monkeypatch
+):
+    """Multi-profile / no 'default' / no pointer is the genuinely ambiguous
+    case that needs explicit user action. The error must:
+    1. Name the available profiles so the user knows what to switch TO
+    2. Suggest /redshift-switch-profile (not /redshift-setup — they already
+       have profiles configured; setup would just add another)
+    """
+    monkeypatch.delenv("REDSHIFT_COMMENT_PROFILE", raising=False)
+    config.write_profile("prod", host="h1", port=5439, user="u", dbname="d")
+    config.write_profile("staging", host="h2", port=5439, user="u", dbname="d")
+    args = _ns()
+    with pytest.raises(ValueError) as excinfo:
+        server.resolve_connection_params(args)
+    msg = str(excinfo.value)
+    assert "prod" in msg
+    assert "staging" in msg
+    assert "/redshift-comment-mcp:redshift-switch-profile" in msg
+
+
+def test_named_profile_typo_error_lists_existing_profiles(
+    tmp_xdg, fake_keyring, monkeypatch
+):
+    """If the user explicitly named a profile (via env or pointer file)
+    that doesn't exist, mention the existing profiles so they can spot
+    the typo — not just 'run /redshift-setup'.
+
+    Note: deliberately picked names that don't share substrings, so
+    `"existing-name" in msg` can't pass on the existing error template
+    (which echoes the typo).
+    """
+    monkeypatch.setenv("REDSHIFT_COMMENT_PROFILE", "wrong-name")
+    config.write_profile("prod-warehouse", host="h", port=5439, user="u", dbname="d")
+    args = _ns()
+    with pytest.raises(ValueError) as excinfo:
+        server.resolve_connection_params(args)
+    msg = str(excinfo.value)
+    # The typo name must be in the error so the user sees the mismatch.
+    assert "wrong-name" in msg
+    # Existing profile must be named so the user can correct the typo.
+    assert "prod-warehouse" in msg


### PR DESCRIPTION
## Problem

PR #22 ([3884f98](../commit/3884f98)) introduced the active-profile pointer file with the implicit contract:

> "Single-profile users never produce the pointer file; **its absence is the canonical 'use default' state**."

That works only when the user's single profile happens to be named `default`. Pre-PR-22 installs let users name the profile at install time (via `userConfig.profile` in the plugin manifest), so anyone whose lone profile was named something else (e.g. `ichef-prod`) gets hard-broken by the upgrade:

1. Server resolves to `"default"` (no pointer, no env, no CLI)
2. `read_profile("default")` returns `None`
3. Server raises pointing at `/redshift-setup`
4. `/redshift-setup` creates another non-`default` profile → loops back to step 1

Discovered when reproducing on another machine; that machine's MCP tools never came online until the user manually wrote the pointer file.

## Fix

### (A) Single-profile fallback in `resolve_active_profile`

When implicit fallback is in play (no CLI flag, no env var, no pointer file):

```
1. If "default" exists in config.toml → use it (backward compat)
2. Else if exactly one profile exists → use that (upgrade rescue)
3. Else return "default" → server raises clear error (improved by C)
```

Explicit inputs (`--profile` flag, `REDSHIFT_COMMENT_PROFILE` env, pointer file) are returned as-is even when they don't resolve — typos surface as typos rather than getting silently redirected.

### (C) Better error message when no rescue applies

The previous "Profile 'default' is not configured. Run /redshift-setup" was misleading when the user already has profiles — `/redshift-setup` just adds another. New message lists existing profiles and points at `/redshift-switch-profile`:

```
Profile 'default' is not configured. 
Existing profiles: prod, staging. 
Run /redshift-comment-mcp:redshift-switch-profile to pick one, 
or /redshift-comment-mcp:redshift-setup to add a new profile.
```

## Test plan

- [x] 8 new tests (4 in `tests/test_config.py`, 4 in `tests/test_server_resolution.py`)
- [x] Full unit suite: 256 passed, 2 skipped (no regression, was 248)
- [x] Live cluster: 22 passed, 1 skipped (no regression)
- [x] E2E wire protocol: 4 passed (no regression)
- [x] Single-profile rescue end-to-end: `ichef-prod`-style profile auto-resolves with no pointer file

## Design decisions

- **Fallback lives in `resolve_active_profile`, not server.py.** The function's contract is "resolve to a usable profile name"; that legitimately depends on what's configured. Splitting policy across files would make the resolution function lie about what exists.
- **Only implicit fallback gets the rescue.** Explicit inputs (CLI/env/pointer) are honored verbatim so typos surface clearly rather than getting silently redirected to the lone profile.
- **No silent magic in the multi-profile ambiguous case.** When there are ≥2 profiles, none named "default", and no pointer file, return "default" so the server raises with the improved error message. Picking one of them silently would be the wrong answer when the user has multiple legitimate clusters.

## Reversibility

Tightly scoped: 28 lines in `config.py`, 14 lines in `server.py`. Pure additive logic; no behavior change for users whose single profile is named "default" (the existing happy path) or who have set a pointer file. Easy revert if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)