### PR TITLE
chore(release): bump 0.4.0 → 0.5.0 + add CLAUDE.md release-discipline rule

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redshift-comment-mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Redshift MCP server with comment-first exploration. 11 tools for schema/table/column listing, hit-count keyword search, and SELECT-only SQL. Comments are authoritative — names are unreliable. Zero-config install: run `/redshift-comment-mcp:redshift-setup` in chat after install — host / user / database via Q&A, password via system dialog (never enters chat), connection verified. Multi-cluster via `/redshift-setup <name>` then `/redshift-switch-profile`.",
   "author": {
     "name": "kouko",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# Project guidance for Claude Code
+
+Conventions and pitfalls specific to this repo. The global preferences
+in `~/.claude/CLAUDE.md` still apply; this file overrides or adds to
+them where the project's needs differ.
+
+## Version bumping (MUST)
+
+This plugin has **two** version fields that must move together. Forgetting
+either ships an inconsistent release:
+
+- `.claude-plugin/plugin.json` — `"version"` field (Claude Code plugin
+  marketplace + install UI read this)
+- `pyproject.toml` — `[tool.setuptools_scm]` `fallback_version` field
+  (the source `uv run` / `pip install` see when there is no `.git`
+  directory, e.g. Claude Code's plugin cache install path)
+
+**When to bump** (pick one per release, semver):
+
+| Change shape | Bump |
+|---|---|
+| Backward-incompatible signature change, removed tool, breaking config / format change | MAJOR (`0.x.y` → `(x+1).0.0` while pre-1.0, semantically still "breaking") |
+| New tool, new field on a tool response, new skill, new server `instructions` directive, additive behavior | MINOR (`x.y.z` → `x.(y+1).0`) |
+| Bug fix, doc fix, test-only change | PATCH (`x.y.z` → `x.y.(z+1)`) |
+
+Tests-only / docs-only / chore commits can ride the next feature bump —
+don't open a PR just to bump for a doc typo.
+
+**Bundle accumulated changes if needed.** If multiple MINOR / PATCH-level
+PRs have merged since the last bump without one, the next bump rolls them
+all up under the highest applicable level. Example: three PATCHes plus
+one MINOR since `0.4.0` → ship `0.5.0` (MINOR shadows PATCH).
+
+**Always bump on the same PR as the user-visible change.** Splitting the
+bump into a separate "release" PR loses the correlation (which PR
+introduced which feature) and risks shipping unbumped code if the bump
+PR slips. The only acceptable exception: chore PRs that have no
+user-visible effect.
+
+## Tests live in three tiers
+
+- `tests/` — unit, runs by default
+- `tests/integration/` — live Redshift cluster, opt-in via
+  `REDSHIFT_INTEGRATION=1`
+- `tests/e2e/` — MCP wire protocol against a real cluster, same opt-in
+
+Run the right tier(s) for the change before merging:
+
+| Change touches | Run |
+|---|---|
+| Pure code logic | `uv run pytest tests/ --ignore=tests/integration --ignore=tests/e2e` |
+| Anything that hits Redshift catalog SQL or `wr.redshift.read_sql_query` | also `REDSHIFT_INTEGRATION=1 uv run pytest tests/integration/` |
+| MCP server `instructions`, tool registration, response field shape, FastMCP serialization | also `REDSHIFT_INTEGRATION=1 uv run pytest tests/e2e/` |
+
+E2E spawns a subprocess per test — ~5s for the four tests. Don't add
+breadth tests there; that's the integration tier's job.
+
+## Profile system gotchas
+
+The active-profile resolution chain (most explicit wins):
+
+```
+--profile CLI flag > REDSHIFT_COMMENT_PROFILE env > ~/.config/.../active-profile file > implicit fallback
+```
+
+Implicit fallback rules (`resolve_active_profile`):
+1. `"default"` if it exists in config.toml
+2. Else if exactly one profile exists, use it (upgrade rescue for
+   pre-PR-22 users)
+3. Else return `"default"` as literal so server raises a clear error
+
+Don't push implicit fallback to the explicit branches — explicit user
+input should be honored verbatim so typos surface as typos, not as
+"silently redirected to the lone profile."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,4 +50,4 @@ redshift-comment-mcp = "redshift_comment_mcp.server:main"
 # .claude-plugin/plugin.json 的 "version" 欄位一同更新。
 [tool.setuptools_scm]
 write_to = "src/redshift_comment_mcp/_version.py"
-fallback_version = "0.4.0"
+fallback_version = "0.5.0"


### PR DESCRIPTION
## Summary

Catches up on accumulated unbumped releases and prevents recurrence.

Two version sources move together (per the explicit comment in pyproject.toml):

| File | Field | Before | After |
|---|---|---|---|
| `.claude-plugin/plugin.json` | `"version"` | 0.4.0 | **0.5.0** |
| `pyproject.toml` | `fallback_version` | 0.4.0 | **0.5.0** |

## What 0.5.0 contains

PRs #22-#29 merged since the last bump at 3884f98. Semver-aggregated to MINOR (MINOR shadows accumulated PATCHes):

- **feat**: `execute_sql` returns `_executed_sql` + `_user_facing_message` (PR #28)
- **feat**: cross-scope `search_tables` / `search_columns` + grep skills (PR #24)
- **feat**: `comment_truncated_count` cap + `scale_hint` multi-item safety (PR #23)
- **fix**: single-profile fallback for non-"default" profile names (PR #29)
- **perf**: column metadata SQL rewritten with direct LEFT JOINs (PR #22)
- **chore**: removed `redshift-cache-schema` skill (PR #26)
- **test**: live-cluster smoke gate + E2E wire tier (PR #25, PR #28)
- **docs**: fixed install.md link (PR #27)

## Why CLAUDE.md is part of this PR

PRs #28 and #29 both shipped without bumping despite the existing pyproject.toml comment saying both fields must move together. That's a process gap, not a single mistake.

CLAUDE.md (new) documents at the project level:

1. **Both version fields must move together** — restated with an explicit when-to-bump table
2. **Bump on the same PR as the user-visible change** — separate "release PRs" lose the bump-PR correlation and risk shipping unbumped code if the release PR slips
3. **Bundle accumulated changes** — the MINOR-shadows-PATCH semver rule with worked example
4. **Two other project-specific conventions** — test tier matrix, profile resolution rules — bundled so the file earns its keep

Bundled the bump and the meta-instruction so the diff is the worked example of the rule.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/integration --ignore=tests/e2e` — 256 passed, 2 skipped (no regression, version is metadata)
- [x] No code path change; bump is mechanical

## Reversibility

Trivial — three files, six lines of substantive change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)