### PR TITLE
docs(claude): add Release publishing (MUST) — tag + GH Release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,43 @@ introduced which feature) and risks shipping unbumped code if the bump
 PR slips. The only acceptable exception: chore PRs that have no
 user-visible effect.
 
+## Release publishing (MUST)
+
+Bumping the two version fields is **not** shipping. The plugin path
+(`claude plugin install`) runs from cloned-repo source, so it sees the
+bump the moment the PR merges. The PyPI path (used by Claude Desktop +
+other MCP clients via `uvx redshift-comment-mcp`) only updates when
+these three steps run after the bump PR merges to `main`:
+
+1. Tag the merge commit and push the tag:
+   ```bash
+   git tag vX.Y.Z       # e.g. v0.5.0 — must match plugin.json + fallback_version
+   git push origin vX.Y.Z
+   ```
+2. **GitHub Releases → Create release from `vX.Y.Z` → ✅ check "Set as a
+   pre-release" → Publish.** This triggers
+   [.github/workflows/test-publish.yml](.github/workflows/test-publish.yml)
+   → TestPyPI smoke test. Wait for the workflow run to go green.
+3. **Edit the same release → ❌ uncheck "Set as a pre-release" →
+   Update.** This triggers
+   [.github/workflows/publish.yml](.github/workflows/publish.yml) →
+   PyPI live.
+
+Verify after step 3:
+```bash
+curl -s https://pypi.org/pypi/redshift-comment-mcp/X.Y.Z/json | jq .info.version
+```
+
+Skipping these steps silently desyncs the two distribution channels —
+exactly what happened between v0.3.0 and v0.5.0 (plugin shipped, PyPI
+stuck two minor versions behind). Full SOP, manual `workflow_dispatch`
+fallback, and troubleshooting:
+[.github/DEPLOYMENT.md](.github/DEPLOYMENT.md).
+
+**PyPI uploads are irreversible.** Once `vX.Y.Z` exists on PyPI, you
+cannot re-upload that version (even after `yank`). The pre-release →
+TestPyPI dry-run in step 2 is what protects you; don't skip it.
+
 ## Tests live in three tiers
 
 - `tests/` — unit, runs by default


### PR DESCRIPTION
## Summary

- `Version bumping (MUST)` mandated bumping `plugin.json` + `pyproject.toml` `fallback_version` together, but **never said** "tag the merge commit and create a GitHub Release". So the actual PyPI ship step was nobody's job.
- Concrete fallout: **v0.4.0 and v0.5.0 both got bumped correctly, but neither was tagged or released.** `.github/workflows/publish.yml` fires on Release `published` events, so it never ran for either. PyPI is stuck at 0.3.0 while the plugin path ships 0.5.0 — a 2-minor desync with no error surfacing.
- This PR adds a `Release publishing (MUST)` H2 section parallel to `Version bumping (MUST)`, listing the three required post-bump steps (`git tag` → Pre-release → Release) and pointing detail at the already-complete `.github/DEPLOYMENT.md` SOP (no duplication).

## Why CLAUDE.md, not README

CLAUDE.md is the contract every future commit reads; README is for end users. The bug was discipline, not docs — the fix has to live where the discipline lives.

## Next steps (after this PR merges)

This branch will walk the new discipline for real:

1. `git tag v0.5.0 7d37358` (the Merge PR #30 commit — main's first 0.5.0-complete state)
2. `git push origin v0.5.0`
3. GitHub Releases → Create release from `v0.5.0` → ✅ Pre-release → Publish → watch `test-publish.yml` go green + TestPyPI shows 0.5.0
4. Edit release → ❌ uncheck Pre-release → Update → watch `publish.yml` go green
5. Verify: `curl -s https://pypi.org/pypi/redshift-comment-mcp/0.5.0/json | jq .info.version` → `"0.5.0"`

Skipping v0.4.0: 0.5.0 is 0.4.0 + a patch (single-profile fallback rescue) superset, and PyPI accepts non-contiguous version numbers. Backfilling 0.4.0 would require tagging an older commit and adds no user value (users on `pip install redshift-comment-mcp` get the latest anyway).

## Test plan

Docs-only — no tests apply.

- [x] CLAUDE.md still parses (read-back verified locally)
- [x] Cross-links to `.github/DEPLOYMENT.md`, `.github/workflows/publish.yml`, `.github/workflows/test-publish.yml` resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)