### PR TITLE
feat(setup): set-password --dialog for code-agent uvx bootstrap (0.6.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redshift-comment-mcp",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Redshift MCP server with comment-first exploration. 11 tools for schema/table/column listing, hit-count keyword search, and SELECT-only SQL. Comments are authoritative — names are unreliable. Zero-config install: run `/redshift-comment-mcp:redshift-setup` in chat after install — host / user / database via Q&A, password via system dialog (never enters chat), connection verified. Multi-cluster via `/redshift-setup <name>` then `/redshift-switch-profile`.",
   "author": {
     "name": "kouko",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,14 @@ name: Publish to PyPI
 
 on:
   release:
-    types: [published]
+    # `published` fires once when a release / pre-release is first published;
+    # `released` fires when an existing pre-release is promoted to a full
+    # release (i.e. user flips "Set as a pre-release" off via UI or
+    # `gh release edit --prerelease=false`). Without `released`, the
+    # Pre-release → Release promotion path never triggers this workflow
+    # and PyPI silently stays stuck on the previous version — see git log
+    # for the v0.5.0 → v0.6.0 incident.
+    types: [published, released]
   workflow_dispatch:  # 允許手動觸發
 
 jobs:

--- a/README.ja.md
+++ b/README.ja.md
@@ -139,6 +139,23 @@ Code プラグインを既に使っているなら、`/redshift-setup` がまっ
 他に便利なサブコマンド：`set-password`、`delete-profile`。
 `uvx redshift-comment-mcp --help` を参照。
 
+**コードエージェントによるブートストラップ**（Bash ツールがあるあらゆる
+MCP クライアント、Claude Code 不要）：非対話の `set-fields` +
+`set-password --dialog` を組み合わせる。`--dialog` フラグは OS ネイティブ
+のパスワードダイアログ（macOS は `osascript`、Linux は `zenity`）を起動
+し、パスワードはチャット / stdout に一切現れません：
+
+```bash
+uvx redshift-comment-mcp set-fields --profile default \
+    --host H --port P --user U --dbname D
+uvx redshift-comment-mcp set-password --profile default --dialog
+```
+
+エージェントはユーザーに host / user / dbname を対話で聞き取り、上記
+2 つのコマンドを実行します。パスワード入力はシステムダイアログ内で
+完結します。ヘッドレス / GUI 無しの環境では `--stdin` で 1 行
+（末尾改行なし）パイプしてください。
+
 **ステップ 2 — シングルプロファイル。** `claude_desktop_config.json`
 （またはクライアントの相当ファイル）に：
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,22 @@ the exact same files; no duplicate setup needed.
 Other useful subcommands: `set-password`, `delete-profile`. See
 `uvx redshift-comment-mcp --help`.
 
+**For code-agent bootstrap** (any MCP client with a Bash tool, no Claude
+Code required): use the non-interactive `set-fields` + `set-password
+--dialog` pair so the password is collected via an OS-native dialog
+(macOS `osascript` / Linux `zenity`) and never enters chat / stdout:
+
+```bash
+uvx redshift-comment-mcp set-fields --profile default \
+    --host H --port P --user U --dbname D
+uvx redshift-comment-mcp set-password --profile default --dialog
+```
+
+The agent asks the user for host/user/dbname conversationally, then runs
+the two commands; password entry happens entirely in the system dialog.
+For headless / non-GUI hosts, use `set-password --stdin` to pipe the
+password instead (one line, no trailing newline).
+
 **Step 2 — single profile.** In `claude_desktop_config.json` (or your
 client's equivalent):
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -132,6 +132,21 @@ service `redshift-comment-mcp` 底下的 OS keychain entry —— 是
 其他常用 subcommand：`set-password`、`delete-profile`。執行
 `uvx redshift-comment-mcp --help` 看完整列表。
 
+**Code agent 自動 bootstrap**（任何有 Bash tool 的 MCP client，不需要
+Claude Code）：用非互動的 `set-fields` + `set-password --dialog` 組合。
+`--dialog` flag 會跳 OS 原生密碼對話框（macOS 用 `osascript`、Linux
+用 `zenity`），**密碼從不進 chat / stdout**：
+
+```bash
+uvx redshift-comment-mcp set-fields --profile default \
+    --host H --port P --user U --dbname D
+uvx redshift-comment-mcp set-password --profile default --dialog
+```
+
+agent 用對話跟使用者要 host / user / dbname、然後跑這兩個命令；密碼
+輸入完全發生在系統對話框內。在 headless / 無 GUI 環境，改用
+`set-password --stdin` pipe 進去（一行，末尾不要換行）。
+
 **步驟 2 —— 單一 profile。** 在 `claude_desktop_config.json`（或你的
 client 對應檔案）：
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,4 +50,4 @@ redshift-comment-mcp = "redshift_comment_mcp.server:main"
 # .claude-plugin/plugin.json 的 "version" 欄位一同更新。
 [tool.setuptools_scm]
 write_to = "src/redshift_comment_mcp/_version.py"
-fallback_version = "0.5.0"
+fallback_version = "0.6.0"

--- a/src/redshift_comment_mcp/server.py
+++ b/src/redshift_comment_mcp/server.py
@@ -33,10 +33,12 @@ def resolve_connection_params(args: argparse.Namespace) -> tuple[str, int, str, 
       ``~/.config/redshift-comment-mcp/config.toml``, password from OS
       keychain.
 
-    Raises ``ValueError`` with a ``/redshift-comment-mcp:redshift-setup``-
-    pointing message if the profile is missing or has no keychain password,
-    so a fresh install with no profile yet surfaces a helpful next step
-    rather than a cryptic stack trace.
+    Raises ``ValueError`` with a dual-path message — pointing at both
+    ``/redshift-comment-mcp:redshift-setup`` (Claude Code skill) and
+    ``redshift-comment-mcp setup`` (CLI, e.g. ``uvx redshift-comment-mcp
+    setup``) — if the profile is missing or has no keychain password.
+    Surfaces a helpful next step regardless of whether the caller has
+    the Claude Code plugin installed.
     """
     inline_complete = bool(args.host and args.user and args.dbname)
     if inline_complete:
@@ -62,13 +64,27 @@ def resolve_connection_params(args: argparse.Namespace) -> tuple[str, int, str, 
             raise ValueError(
                 f"Profile '{profile_name}' is not configured. "
                 f"Existing profiles: {', '.join(existing)}. "
-                f"Run /redshift-comment-mcp:redshift-switch-profile to pick one, "
-                f"or /redshift-comment-mcp:redshift-setup to add a new profile."
+                f"To switch: /redshift-comment-mcp:redshift-switch-profile (Claude Code), "
+                f"or pass `--profile <name>` to redshift-comment-mcp / set "
+                f"`REDSHIFT_COMMENT_PROFILE=<name>` env var. "
+                f"To add a new profile: /redshift-comment-mcp:redshift-setup (Claude Code), "
+                f"or `redshift-comment-mcp setup --profile <name>` (terminal), "
+                f"or code-agent pipeline `set-fields ... && set-password --dialog`."
             )
         raise ValueError(
-            f"Profile '{profile_name}' is not configured. "
-            f"Run /redshift-comment-mcp:redshift-setup in chat to set up "
-            f"your Redshift connection (no terminal commands needed)."
+            f"Profile '{profile_name}' is not configured. Configure via one of:"
+            f"  - Claude Code: /redshift-comment-mcp:redshift-setup in chat "
+            f"(password collected via system dialog, never enters chat). "
+            f"  - Code agent (any MCP client with Bash): "
+            f"`redshift-comment-mcp set-fields --profile {profile_name} "
+            f"--host H --port P --user U --dbname D` "
+            f"then `redshift-comment-mcp set-password --profile {profile_name} --dialog` "
+            f"— the `--dialog` flag launches an OS-native password prompt "
+            f"(macOS osascript / Linux zenity) so the password never enters "
+            f"chat / stdout. Ask the user for host/user/dbname interactively; "
+            f"never invent them. "
+            f"  - Human in terminal: `uvx redshift-comment-mcp setup --profile {profile_name}` "
+            f"(full interactive Q&A)."
         )
     password = cfg.get_password(profile_name)
     if not password:

--- a/src/redshift_comment_mcp/setup_cli.py
+++ b/src/redshift_comment_mcp/setup_cli.py
@@ -3,19 +3,35 @@
 Subcommands (invoked as ``redshift-comment-mcp <subcommand>``):
 
 - ``setup [--profile NAME]``        — full Q&A for one profile
-- ``set-password [--profile NAME]`` — only update the password
+- ``set-password [--profile NAME] [--stdin | --dialog]``
+                                     — update password.
+                                     Default = interactive ``getpass`` prompt.
+                                     ``--stdin``: read one line from stdin
+                                     (scripted / CI use; never logs to argv).
+                                     ``--dialog``: OS-native password dialog
+                                     (macOS ``osascript``, Linux ``zenity``);
+                                     password never enters chat / stdout.
 - ``test-connection [--profile NAME]`` — verify a profile can connect
 - ``list-profiles``                  — list all configured profiles
 - ``delete-profile --profile NAME``  — remove a profile + its keyring entry
+- ``set-fields --profile NAME --host H --port P --user U --dbname D``
+                                     — non-interactive write of the 4
+                                     non-secret fields (agent / scripted use).
 
 Subcommands route through ``main()`` in this module; the bare command
 ``redshift-comment-mcp`` (with no subcommand) starts the MCP server in
 ``server.py``.
+
+Code-agent bootstrap pipeline (no Claude Code plugin required)::
+
+    redshift-comment-mcp set-fields --profile X --host H --port P --user U --dbname D
+    redshift-comment-mcp set-password --profile X --dialog
 """
 from __future__ import annotations
 
 import argparse
 import getpass
+import subprocess
 import sys
 
 from . import config
@@ -52,6 +68,69 @@ def cmd_setup(args: argparse.Namespace) -> int:
     return cmd_test_connection(args)
 
 
+def _collect_password_via_dialog(profile_name: str) -> tuple[str | None, str]:
+    """Collect password via OS-native dialog without exposing to chat / stdout.
+
+    Returns ``(password, reason)``:
+      - ``("the-password", "ok")`` on success
+      - ``(None, "cancelled")`` if user closed / cancelled the dialog
+      - ``(None, "unavailable")`` if no dialog tool is installed
+      - ``(None, "unsupported")`` if the platform has no supported dialog path
+
+    Mirrors the security discipline of ``skills/redshift-setup/references/
+    password-macos.md`` / ``password-zenity.md``: the password value is
+    captured into a local Python string via ``subprocess.run(capture_output=
+    True)`` and never reaches the caller's stdout. The caller is responsible
+    for passing it directly to ``config.set_password()`` and deleting the
+    reference immediately.
+    """
+    if sys.platform == "darwin":
+        # macOS — native osascript dialog. "with hidden answer" masks the
+        # typed value. stderr is discarded so a Cocoa permission/cancel
+        # error doesn't leak user-visible state.
+        script = (
+            f'tell application "System Events" to display dialog '
+            f'"Redshift password for profile \\"{profile_name}\\":" '
+            f'default answer "" with hidden answer '
+            f'with title "Redshift MCP Setup" '
+            f'buttons {{"Cancel", "Save"}} default button "Save"'
+        )
+        try:
+            result = subprocess.run(
+                ["osascript", "-e", script, "-e", "text returned of result"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except FileNotFoundError:
+            return None, "unavailable"
+        if result.returncode != 0:
+            return None, "cancelled"
+        return result.stdout.rstrip("\n"), "ok"
+
+    if sys.platform.startswith("linux"):
+        # Linux desktop — zenity. Exit code 1 = cancelled, 127 = not installed.
+        try:
+            result = subprocess.run(
+                [
+                    "zenity",
+                    "--password",
+                    "--title=Redshift MCP Setup",
+                    f"--text=Redshift password for profile \"{profile_name}\":",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except FileNotFoundError:
+            return None, "unavailable"
+        if result.returncode == 0:
+            return result.stdout.rstrip("\n"), "ok"
+        return None, "cancelled"
+
+    return None, "unsupported"
+
+
 def cmd_set_password(args: argparse.Namespace) -> int:
     name = args.profile
     if not config.read_profile(name):
@@ -61,10 +140,50 @@ def cmd_set_password(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
-    password = getpass.getpass(f"DB password for profile '{name}' (input hidden): ")
-    if not password:
-        print("Password cannot be empty. Aborting.", file=sys.stderr)
-        return 2
+
+    if args.dialog:
+        password, reason = _collect_password_via_dialog(name)
+        if reason == "cancelled":
+            print("Password dialog cancelled. No change.", file=sys.stderr)
+            return 2
+        if reason == "unavailable":
+            print(
+                "No supported password dialog tool found "
+                "(macOS needs `osascript`, Linux needs `zenity`). "
+                "Use `--stdin` to pipe the password, or omit both flags "
+                "for an interactive terminal prompt.",
+                file=sys.stderr,
+            )
+            return 2
+        if reason == "unsupported":
+            print(
+                f"`--dialog` is not supported on platform '{sys.platform}'. "
+                f"Use `--stdin` to pipe the password, or omit both flags "
+                f"for an interactive terminal prompt.",
+                file=sys.stderr,
+            )
+            return 2
+        if not password:
+            print("Password from dialog is empty. Aborting.", file=sys.stderr)
+            return 2
+    elif args.stdin:
+        # Non-interactive: scripted use + code-agent automation when no GUI
+        # is available. Caller pipes one line of password text via stdin so
+        # the password never lands in argv (visible to `ps`) or shell
+        # history. Prefer `--dialog` on GUI hosts.
+        password = sys.stdin.readline().rstrip("\n")
+        if not password:
+            print(
+                "Password from --stdin is empty. Aborting "
+                "(pass exactly one line of password text via stdin).",
+                file=sys.stderr,
+            )
+            return 2
+    else:
+        password = getpass.getpass(f"DB password for profile '{name}' (input hidden): ")
+        if not password:
+            print("Password cannot be empty. Aborting.", file=sys.stderr)
+            return 2
     config.set_password(name, password)
     print(f"✓ Updated password for profile '{name}'.")
     return 0
@@ -203,6 +322,24 @@ def main(argv: list[str] | None = None) -> int:
 
     spw = sub.add_parser("set-password", help="Update the password for an existing profile.")
     spw.add_argument("--profile", default="default")
+    spw_pwsrc = spw.add_mutually_exclusive_group()
+    spw_pwsrc.add_argument(
+        "--stdin",
+        action="store_true",
+        help=(
+            "Read password from stdin (one line) instead of an interactive "
+            "prompt. For scripted / CI use; never logs password to argv."
+        ),
+    )
+    spw_pwsrc.add_argument(
+        "--dialog",
+        action="store_true",
+        help=(
+            "Collect password via OS-native dialog (macOS osascript / "
+            "Linux zenity). Password value never enters chat / stdout. "
+            "Recommended for code-agent setup pipelines."
+        ),
+    )
     spw.set_defaults(func=cmd_set_password)
 
     stc = sub.add_parser("test-connection", help="Verify a profile can connect.")

--- a/tests/test_server_resolution.py
+++ b/tests/test_server_resolution.py
@@ -5,7 +5,9 @@ comes from, what error message a fresh install sees — was 0% covered
 before the D2 refactor. This file pins down the resolution priority
 (CLI flag > REDSHIFT_COMMENT_PROFILE env > active-profile pointer file >
 ``"default"``) and the user-facing error messages that point a stuck
-user back at ``/redshift-comment-mcp:redshift-setup``.
+user back at both ``/redshift-comment-mcp:redshift-setup`` (Claude
+Code skill) and ``redshift-comment-mcp setup`` (CLI fallback for
+uvx-only / non-Claude-Code installs).
 """
 from __future__ import annotations
 
@@ -159,10 +161,13 @@ def test_profile_mode_cli_flag_beats_env_and_file(tmp_xdg, fake_keyring, monkeyp
     assert server.resolve_connection_params(args)[0] == "prod.example.com"
 
 
-# ===== profile mode error messages point at the skill =====
+# ===== profile mode error messages point at both skill and CLI =====
 
 
-def test_profile_not_configured_error_points_at_skill(tmp_xdg, fake_keyring, monkeypatch):
+def test_profile_not_configured_error_offers_three_paths(tmp_xdg, fake_keyring, monkeypatch):
+    """Error must surface all three setup paths so any caller can recover:
+    Claude Code skill, code-agent pipeline (set-fields + set-password
+    --dialog), and human terminal (uvx redshift-comment-mcp setup)."""
     monkeypatch.delenv("REDSHIFT_COMMENT_PROFILE", raising=False)
     args = _ns()
     with pytest.raises(ValueError) as excinfo:
@@ -170,7 +175,16 @@ def test_profile_not_configured_error_points_at_skill(tmp_xdg, fake_keyring, mon
     msg = str(excinfo.value)
     assert "default" in msg, "Error should name the profile"
     assert "/redshift-comment-mcp:redshift-setup" in msg, (
-        "Error should point at the skill, not the legacy uvx CLI command"
+        "Path 1 — Claude Code skill — should be mentioned"
+    )
+    assert "set-fields" in msg and "--dialog" in msg, (
+        "Path 2 — code-agent pipeline (set-fields + set-password --dialog) — "
+        "should be mentioned so non-Claude-Code agents can bootstrap without "
+        "the password entering chat"
+    )
+    assert "redshift-comment-mcp setup" in msg, (
+        "Path 3 — human terminal (uvx redshift-comment-mcp setup) — should "
+        "be mentioned for users running the setup themselves interactively"
     )
 
 

--- a/tests/test_setup_cli.py
+++ b/tests/test_setup_cli.py
@@ -274,3 +274,138 @@ def test_set_password_empty_returns_2(tmp_xdg, fake_keyring, monkeypatch, capsys
     rc = setup_cli.main(["set-password", "--profile", "default"])
     assert rc == 2
     assert "cannot be empty" in capsys.readouterr().err
+
+
+# ===== set-password --stdin =====
+
+
+def test_set_password_stdin_reads_one_line_updates_keychain(
+    tmp_xdg, fake_keyring, monkeypatch, capsys
+):
+    """Caller pipes password via stdin → keychain. No interactive prompt."""
+    config.write_profile("default", host="h", port=5439, user="u", dbname="d")
+    import io
+    monkeypatch.setattr("sys.stdin", io.StringIO("piped-secret\n"))
+
+    rc = setup_cli.main(["set-password", "--profile", "default", "--stdin"])
+    assert rc == 0
+    assert config.get_password("default") == "piped-secret"
+    assert "Updated password" in capsys.readouterr().out
+
+
+def test_set_password_stdin_empty_returns_2(tmp_xdg, fake_keyring, monkeypatch, capsys):
+    """Empty stdin must error so an agent doesn't silently store an empty password."""
+    config.write_profile("default", host="h", port=5439, user="u", dbname="d")
+    import io
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+
+    rc = setup_cli.main(["set-password", "--profile", "default", "--stdin"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "--stdin" in err and "empty" in err
+
+
+# ===== set-password --dialog =====
+
+
+def _mock_subprocess_run(returncode: int, stdout: str = "", raise_=None):
+    """Build a subprocess.run replacement that returns a fake CompletedProcess
+    (or raises) so dialog paths can be exercised without launching osascript /
+    zenity in tests."""
+    def _run(*_args, **_kwargs):
+        if raise_ is not None:
+            raise raise_
+        return types.SimpleNamespace(returncode=returncode, stdout=stdout, stderr="")
+    return _run
+
+
+def test_set_password_dialog_macos_happy_path(tmp_xdg, fake_keyring, monkeypatch, capsys):
+    """macOS osascript dialog returns the typed password on stdout (captured
+    by subprocess.run); CLI writes it to keychain without echoing."""
+    config.write_profile("default", host="h", port=5439, user="u", dbname="d")
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setattr(
+        "redshift_comment_mcp.setup_cli.subprocess.run",
+        _mock_subprocess_run(returncode=0, stdout="dialog-secret\n"),
+    )
+
+    rc = setup_cli.main(["set-password", "--profile", "default", "--dialog"])
+    assert rc == 0
+    assert config.get_password("default") == "dialog-secret"
+    out = capsys.readouterr().out
+    assert "Updated password" in out
+    assert "dialog-secret" not in out  # password must never reach stdout
+
+
+def test_set_password_dialog_linux_zenity_happy_path(
+    tmp_xdg, fake_keyring, monkeypatch, capsys
+):
+    config.write_profile("default", host="h", port=5439, user="u", dbname="d")
+    monkeypatch.setattr("sys.platform", "linux")
+    monkeypatch.setattr(
+        "redshift_comment_mcp.setup_cli.subprocess.run",
+        _mock_subprocess_run(returncode=0, stdout="zenity-secret\n"),
+    )
+
+    rc = setup_cli.main(["set-password", "--profile", "default", "--dialog"])
+    assert rc == 0
+    assert config.get_password("default") == "zenity-secret"
+
+
+def test_set_password_dialog_cancelled_returns_2(
+    tmp_xdg, fake_keyring, monkeypatch, capsys
+):
+    """User clicks Cancel → dialog returncode != 0 → CLI exits 2, no write."""
+    config.write_profile("default", host="h", port=5439, user="u", dbname="d")
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setattr(
+        "redshift_comment_mcp.setup_cli.subprocess.run",
+        _mock_subprocess_run(returncode=1, stdout=""),
+    )
+
+    rc = setup_cli.main(["set-password", "--profile", "default", "--dialog"])
+    assert rc == 2
+    assert config.get_password("default") is None
+    assert "cancelled" in capsys.readouterr().err.lower()
+
+
+def test_set_password_dialog_tool_unavailable_returns_2(
+    tmp_xdg, fake_keyring, monkeypatch, capsys
+):
+    """osascript / zenity not installed → CLI exits 2 with a clear fallback hint."""
+    config.write_profile("default", host="h", port=5439, user="u", dbname="d")
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setattr(
+        "redshift_comment_mcp.setup_cli.subprocess.run",
+        _mock_subprocess_run(returncode=0, raise_=FileNotFoundError("osascript")),
+    )
+
+    rc = setup_cli.main(["set-password", "--profile", "default", "--dialog"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "--stdin" in err  # fallback hint
+    assert "osascript" in err or "zenity" in err
+
+
+def test_set_password_dialog_unsupported_platform_returns_2(
+    tmp_xdg, fake_keyring, monkeypatch, capsys
+):
+    config.write_profile("default", host="h", port=5439, user="u", dbname="d")
+    monkeypatch.setattr("sys.platform", "win32")
+
+    rc = setup_cli.main(["set-password", "--profile", "default", "--dialog"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "win32" in err
+    assert "--stdin" in err  # fallback hint
+
+
+def test_set_password_stdin_and_dialog_are_mutually_exclusive(
+    tmp_xdg, fake_keyring, capsys
+):
+    """argparse mutually_exclusive_group: --stdin and --dialog can't co-occur."""
+    config.write_profile("default", host="h", port=5439, user="u", dbname="d")
+    with pytest.raises(SystemExit) as excinfo:
+        setup_cli.main(["set-password", "--profile", "default", "--stdin", "--dialog"])
+    assert excinfo.value.code == 2
+    assert "not allowed with argument" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

PR #32 documented `uvx redshift-comment-mcp` as a first-class install path but left a real gap: **code agents in non-Claude-Code MCP clients had no way to provision a profile without the password passing through the chat transcript.** The Claude Code `/redshift-setup` skill solved this via OS-aware dialogs ([password-macos.md](skills/redshift-setup/references/password-macos.md) / [password-zenity.md](skills/redshift-setup/references/password-zenity.md)) — that pattern is now ported into the CLI itself.

Plus: the `publish.yml` trigger bug that bit v0.5.0 (`gh release edit --prerelease=false` doesn't fire `published`) is fixed forward — v0.6.0 will actually reach PyPI.

## Changes

### Feature: `set-password --dialog`

Ports `osascript` (macOS) / `zenity` (Linux) password collection into the CLI. Password value goes via `subprocess.run(capture_output=True)` directly into a Python string → `keyring.set_password()` → OS keychain. **Never** reaches: chat, stdout, process args, shell history.

```bash
# code-agent bootstrap (Claude Desktop / Cursor / any MCP client with Bash)
uvx redshift-comment-mcp set-fields --profile default \\
    --host H --port P --user U --dbname D
uvx redshift-comment-mcp set-password --profile default --dialog
# (System dialog appears; user types password in the dialog;
#  CLI stores in keychain; only "✓ Updated password" reaches stdout)
```

Falls back cleanly with helpful error if osascript/zenity not installed or platform unsupported (Windows). Companion `--stdin` flag for headless/CI use (mutually exclusive with `--dialog`).

### Fix: server.py error messages now offer all 3 setup paths

[server.py:62-79](src/redshift_comment_mcp/server.py#L62-L79) Branch A (wrong profile name) + Branch B (no profile at all):

| Path | Audience |
|---|---|
| `/redshift-comment-mcp:redshift-setup` | Claude Code + plugin |
| `set-fields ... && set-password --dialog` | code agent in any MCP client with Bash |
| `uvx redshift-comment-mcp setup --profile X` | human in terminal |

Before, both branches only mentioned the Claude Code skill — uvx-only users hit a dead-end error.

### Fix: publish.yml release trigger

[publish.yml:5](.github/workflows/publish.yml#L5) `types: [published, released]`. The `released` activity fires when a Pre-release is promoted to non-prerelease via `gh release edit --prerelease=false` — the v0.5.0 path that left PyPI silently stuck on 0.3.0. With this fix, the Pre-release → TestPyPI → Release → PyPI flow documented in [DEPLOYMENT.md](.github/DEPLOYMENT.md) actually works.

### Version bump 0.5.0 → 0.6.0

`--dialog` and `--stdin` are additive flags → MINOR per CLAUDE.md. v0.5.0 PyPI is **skipped**; v0.6.0 rolls up everything since the last PyPI release (v0.3.0) + this PR's work into a single PyPI release.

### Trilingual README updates

[README.md](README.md) / [README.ja.md](README.ja.md) / [README.zh-TW.md](README.zh-TW.md) all gain the code-agent bootstrap snippet showing the `set-fields` + `set-password --dialog` pipeline.

## Test plan

- [x] `pytest tests/ --ignore=tests/integration --ignore=tests/e2e` → 264 passed, 2 skipped (+7 new tests for the new flags)
- [x] New tests in [test_setup_cli.py](tests/test_setup_cli.py): `--stdin` happy/empty, `--dialog` macOS/linux/cancel/unavailable/unsupported, `--stdin` + `--dialog` mutual exclusion
- [x] Updated [test_server_resolution.py](tests/test_server_resolution.py): assertion expanded from "skill only" to "all 3 paths present"
- [x] `test_pyproject_plugin_version_sync` invariant: 0.6.0 = 0.6.0 ✓
- [ ] Post-merge: tag `v0.6.0`, create GH Pre-release → watch test-publish.yml → flip to Release → watch publish.yml → PyPI verifies `0.6.0` available

## Memory trailers (in commit body)

- **Decision**: split into `--dialog` + `--stdin` rather than one `--noninteractive` flag (two security tiers documented)
- **Learning**: `osascript` stdout-leak avoided by `subprocess.run(capture_output=True)` keeping value in-process
- **Gotcha**: GitHub release `edit prerelease=false` fires `released` not `published` — workflows listening only on `[published]` miss it

🤖 Generated with [Claude Code](https://claude.com/claude-code)