### PR TITLE
feat(0.7.0): degraded-mode startup + setup_via_dialog MCP tool

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redshift-comment-mcp",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Redshift MCP server with comment-first exploration. 11 tools for schema/table/column listing, hit-count keyword search, and SELECT-only SQL. Comments are authoritative — names are unreliable. Zero-config install: run `/redshift-comment-mcp:redshift-setup` in chat after install — host / user / database via Q&A, password via system dialog (never enters chat), connection verified. Multi-cluster via `/redshift-setup <name>` then `/redshift-switch-profile`.",
   "author": {
     "name": "kouko",

--- a/README.ja.md
+++ b/README.ja.md
@@ -38,7 +38,7 @@ SQL は繰り返しが多すぎる。
 
 ## 含まれているもの
 
-### MCP ツール（11 個、[`src/redshift_comment_mcp/`](src/redshift_comment_mcp/) で定義）
+### MCP ツール（12 個、[`src/redshift_comment_mcp/`](src/redshift_comment_mcp/) で定義）
 
 | グループ | ツール |
 |---|---|
@@ -46,6 +46,7 @@ SQL は繰り返しが多すぎる。
 | Search（ヒット数順） | `search_schemas` · `search_tables` · `search_columns` |
 | コメント取得 | `get_schema_comment` · `get_table_comment` · `get_column_comment` · `get_all_column_comments` |
 | クエリ | `execute_sql`（SELECT / WITH のみ） |
+| セットアップ（v0.7.0〜） | `setup_via_dialog` — セッション内でプロファイルをブートストラップ。パスワードは OS ネイティブダイアログで収集し、MCP wire には一切流れない |
 
 list / search はすべてページング対応。コメントを読んでから名前を信じる
 よう LLM を促す `WARNING` 文字列が明示的に埋め込まれています。
@@ -139,22 +140,38 @@ Code プラグインを既に使っているなら、`/redshift-setup` がまっ
 他に便利なサブコマンド：`set-password`、`delete-profile`。
 `uvx redshift-comment-mcp --help` を参照。
 
-**コードエージェントによるブートストラップ**（Bash ツールがあるあらゆる
-MCP クライアント、Claude Code 不要）：非対話の `set-fields` +
-`set-password --dialog` を組み合わせる。`--dialog` フラグは OS ネイティブ
-のパスワードダイアログ（macOS は `osascript`、Linux は `zenity`）を起動
-し、パスワードはチャット / stdout に一切現れません：
+**コードエージェントによるブートストラップ**（任意の MCP クライアント、
+v0.7.0 〜）：推奨パスはインバンドの MCP ツール `setup_via_dialog` —
+Bash ツール不要、MCP クライアント再起動不要、パスワードはチャットに
+一切現れません：
+
+```
+agent が任意の DB ツールを呼ぶ        → {"error": "not_configured", "next_step": "Call setup_via_dialog..."}
+agent がユーザーに host / user / dbname を聞く（これらは機密ではない）
+agent が MCP ツール setup_via_dialog(host=..., user=..., dbname=...) を呼ぶ
+                                     → サーバー側で OS ダイアログ起動（macOS osascript / Linux zenity）
+                                     → ユーザーがダイアログに直接パスワードを入力
+                                     → サーバーが config.toml + keychain に書き込む
+                                     → {"status": "configured", ...}
+agent が DB ツールを再試行           → 動作（lazy resolve；再起動不要）
+```
+
+サーバーはプロファイル未設定でも **デグレードモード** で起動します ——
+DB ツールは構造化された `not_configured` エラーを返し、その中で
+`setup_via_dialog` を案内するので、エージェントはツール呼び出しの
+結果から復旧パスを直接見られます（MCP クライアントのログファイルを
+読みに行く必要はありません）。セットアップ後の次回ツール呼び出しで
+lazy resolution が新プロファイルを拾います。
+
+**ヘッドレス / GUI 無しホスト**（`osascript` も `zenity` も無い場合）
+**のフォールバック**：Bash + CLI 経由で `--stdin` を使うパスに落ちます：
 
 ```bash
 uvx redshift-comment-mcp set-fields --profile default \
     --host H --port P --user U --dbname D
-uvx redshift-comment-mcp set-password --profile default --dialog
+echo "$PASSWORD" | uvx redshift-comment-mcp set-password \
+    --profile default --stdin
 ```
-
-エージェントはユーザーに host / user / dbname を対話で聞き取り、上記
-2 つのコマンドを実行します。パスワード入力はシステムダイアログ内で
-完結します。ヘッドレス / GUI 無しの環境では `--stdin` で 1 行
-（末尾改行なし）パイプしてください。
 
 **ステップ 2 — シングルプロファイル。** `claude_desktop_config.json`
 （またはクライアントの相当ファイル）に：

--- a/README.ja.md
+++ b/README.ja.md
@@ -38,7 +38,7 @@ SQL は繰り返しが多すぎる。
 
 ## 含まれているもの
 
-### MCP ツール（12 個、[`src/redshift_comment_mcp/`](src/redshift_comment_mcp/) で定義）
+### MCP ツール（13 個、[`src/redshift_comment_mcp/`](src/redshift_comment_mcp/) で定義）
 
 | グループ | ツール |
 |---|---|
@@ -46,7 +46,7 @@ SQL は繰り返しが多すぎる。
 | Search（ヒット数順） | `search_schemas` · `search_tables` · `search_columns` |
 | コメント取得 | `get_schema_comment` · `get_table_comment` · `get_column_comment` · `get_all_column_comments` |
 | クエリ | `execute_sql`（SELECT / WITH のみ） |
-| セットアップ（v0.7.0〜） | `setup_via_dialog` — セッション内でプロファイルをブートストラップ。パスワードは OS ネイティブダイアログで収集し、MCP wire には一切流れない |
+| セットアップ（v0.7.0〜） | `setup_via_dialog` — セッション内でプロファイルをブートストラップ。パスワードは OS ネイティブダイアログで収集し、MCP wire には一切流れない；成功宣言前に接続テストも実施 · `get_setup_status` — 読み取り専用の設定状態チェック。セッション開始時に安全に呼び出せ、パスワード値は決して返さない |
 
 list / search はすべてページング対応。コメントを読んでから名前を信じる
 よう LLM を促す `WARNING` 文字列が明示的に埋め込まれています。

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ full charter.
 
 ## What you get
 
-### MCP tools (12, defined in [`src/redshift_comment_mcp/`](src/redshift_comment_mcp/))
+### MCP tools (13, defined in [`src/redshift_comment_mcp/`](src/redshift_comment_mcp/))
 
 | Group | Tools |
 |---|---|
@@ -46,7 +46,7 @@ full charter.
 | Search (hit-count ranked) | `search_schemas` · `search_tables` · `search_columns` |
 | Comment retrieval | `get_schema_comment` · `get_table_comment` · `get_column_comment` · `get_all_column_comments` |
 | Query | `execute_sql` (SELECT / WITH only) |
-| Setup (since v0.7.0) | `setup_via_dialog` — in-band profile bootstrap; OS-native password dialog, never crosses MCP wire |
+| Setup (since v0.7.0) | `setup_via_dialog` — in-band profile bootstrap; OS-native password dialog, never crosses MCP wire; tests connection before declaring success · `get_setup_status` — read-only configuration check; safe to call at session start; never returns password value |
 
 Pagination on every list / search; explicit `WARNING` strings nudging
 the LLM to read comments before trusting names.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ full charter.
 
 ## What you get
 
-### MCP tools (11, defined in [`src/redshift_comment_mcp/`](src/redshift_comment_mcp/))
+### MCP tools (12, defined in [`src/redshift_comment_mcp/`](src/redshift_comment_mcp/))
 
 | Group | Tools |
 |---|---|
@@ -46,6 +46,7 @@ full charter.
 | Search (hit-count ranked) | `search_schemas` · `search_tables` · `search_columns` |
 | Comment retrieval | `get_schema_comment` · `get_table_comment` · `get_column_comment` · `get_all_column_comments` |
 | Query | `execute_sql` (SELECT / WITH only) |
+| Setup (since v0.7.0) | `setup_via_dialog` — in-band profile bootstrap; OS-native password dialog, never crosses MCP wire |
 
 Pagination on every list / search; explicit `WARNING` strings nudging
 the LLM to read comments before trusting names.
@@ -139,21 +140,37 @@ the exact same files; no duplicate setup needed.
 Other useful subcommands: `set-password`, `delete-profile`. See
 `uvx redshift-comment-mcp --help`.
 
-**For code-agent bootstrap** (any MCP client with a Bash tool, no Claude
-Code required): use the non-interactive `set-fields` + `set-password
---dialog` pair so the password is collected via an OS-native dialog
-(macOS `osascript` / Linux `zenity`) and never enters chat / stdout:
+**For code-agent bootstrap** (any MCP client, since v0.7.0): the
+preferred path is the in-band MCP tool `setup_via_dialog` — no Bash
+tool, no MCP client restart, password stays out of chat:
+
+```
+agent calls any DB tool          → {"error": "not_configured", "next_step": "Call setup_via_dialog..."}
+agent asks user for host/user/dbname  (these are NOT secrets)
+agent calls MCP tool setup_via_dialog(host=..., user=..., dbname=...)
+                                 → server-side spawns OS dialog (macOS osascript / Linux zenity)
+                                 → user types password directly into dialog
+                                 → server writes config.toml + keychain
+                                 → {"status": "configured", ...}
+agent retries the DB tool        → works (lazy resolve; no restart needed)
+```
+
+The server boots in **degraded mode** even when no profile exists —
+DB tools return a structured `not_configured` error pointing at
+`setup_via_dialog`, so the agent sees the recovery path in its own
+tool-call result (no need to read MCP client log files). After setup,
+lazy resolution picks up the new profile on the next tool call.
+
+**Fallback for headless / non-GUI hosts** (no `osascript` / no
+`zenity`): drop to the Bash + CLI path which uses `--stdin` instead of
+the dialog:
 
 ```bash
 uvx redshift-comment-mcp set-fields --profile default \
     --host H --port P --user U --dbname D
-uvx redshift-comment-mcp set-password --profile default --dialog
+echo "$PASSWORD" | uvx redshift-comment-mcp set-password \
+    --profile default --stdin
 ```
-
-The agent asks the user for host/user/dbname conversationally, then runs
-the two commands; password entry happens entirely in the system dialog.
-For headless / non-GUI hosts, use `set-password --stdin` to pipe the
-password instead (one line, no trailing newline).
 
 **Step 2 — single profile.** In `claude_desktop_config.json` (or your
 client's equivalent):

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -34,7 +34,7 @@ manifest 涵蓋面太窄、Web GUI 太慢、手刻 SQL 太重複。
 
 ## 你能拿到什麼
 
-### MCP tools（11 支，定義在 [`src/redshift_comment_mcp/`](src/redshift_comment_mcp/)）
+### MCP tools（12 支，定義在 [`src/redshift_comment_mcp/`](src/redshift_comment_mcp/)）
 
 | 群組 | Tools |
 |---|---|
@@ -42,6 +42,7 @@ manifest 涵蓋面太窄、Web GUI 太慢、手刻 SQL 太重複。
 | Search（依命中關鍵字數排序） | `search_schemas` · `search_tables` · `search_columns` |
 | 註解擷取 | `get_schema_comment` · `get_table_comment` · `get_column_comment` · `get_all_column_comments` |
 | Query | `execute_sql`（只接受 SELECT / WITH） |
+| Setup（v0.7.0 起） | `setup_via_dialog` —— 在 session 內 bootstrap profile；密碼用 OS 原生對話框收集，**完全不過 MCP wire** |
 
 每支 list / search 都有分頁；明確的 `WARNING` 字串會推 LLM 先讀註解
 再相信名字。
@@ -132,20 +133,36 @@ service `redshift-comment-mcp` 底下的 OS keychain entry —— 是
 其他常用 subcommand：`set-password`、`delete-profile`。執行
 `uvx redshift-comment-mcp --help` 看完整列表。
 
-**Code agent 自動 bootstrap**（任何有 Bash tool 的 MCP client，不需要
-Claude Code）：用非互動的 `set-fields` + `set-password --dialog` 組合。
-`--dialog` flag 會跳 OS 原生密碼對話框（macOS 用 `osascript`、Linux
-用 `zenity`），**密碼從不進 chat / stdout**：
+**Code agent 自動 bootstrap**（任何 MCP client，v0.7.0 起）：首選路徑
+是 in-band MCP tool `setup_via_dialog` —— 不用 Bash tool、不用重啟
+MCP client、密碼**完全不入 chat**：
+
+```
+agent 呼任何 DB tool              → {"error": "not_configured", "next_step": "Call setup_via_dialog..."}
+agent 跟使用者要 host / user / dbname（這些不是 secret）
+agent 呼 MCP tool setup_via_dialog(host=..., user=..., dbname=...)
+                                  → server 端跳 OS 對話框（macOS osascript / Linux zenity）
+                                  → 使用者直接在對話框輸入密碼
+                                  → server 寫 config.toml + keychain
+                                  → {"status": "configured", ...}
+agent 重試 DB tool                → 成功（lazy resolve；不需要重啟）
+```
+
+Server 即使**沒有 profile** 也會以 **degraded mode 啟動** —— DB tool
+回傳結構化的 `not_configured` 錯誤，指向 `setup_via_dialog`，所以
+agent 可以直接從自己的 tool-call 結果看到復原路徑（不用去翻 MCP client
+的 log 檔）。setup 完之後下一次 tool call 由 lazy resolution 撿到
+新 profile。
+
+**Headless / 無 GUI host 的 fallback**（沒 `osascript` 也沒 `zenity`）：
+退回到 Bash + CLI 路徑、用 `--stdin` 代替對話框：
 
 ```bash
 uvx redshift-comment-mcp set-fields --profile default \
     --host H --port P --user U --dbname D
-uvx redshift-comment-mcp set-password --profile default --dialog
+echo "$PASSWORD" | uvx redshift-comment-mcp set-password \
+    --profile default --stdin
 ```
-
-agent 用對話跟使用者要 host / user / dbname、然後跑這兩個命令；密碼
-輸入完全發生在系統對話框內。在 headless / 無 GUI 環境，改用
-`set-password --stdin` pipe 進去（一行，末尾不要換行）。
 
 **步驟 2 —— 單一 profile。** 在 `claude_desktop_config.json`（或你的
 client 對應檔案）：

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -34,7 +34,7 @@ manifest 涵蓋面太窄、Web GUI 太慢、手刻 SQL 太重複。
 
 ## 你能拿到什麼
 
-### MCP tools（12 支，定義在 [`src/redshift_comment_mcp/`](src/redshift_comment_mcp/)）
+### MCP tools（13 支，定義在 [`src/redshift_comment_mcp/`](src/redshift_comment_mcp/)）
 
 | 群組 | Tools |
 |---|---|
@@ -42,7 +42,7 @@ manifest 涵蓋面太窄、Web GUI 太慢、手刻 SQL 太重複。
 | Search（依命中關鍵字數排序） | `search_schemas` · `search_tables` · `search_columns` |
 | 註解擷取 | `get_schema_comment` · `get_table_comment` · `get_column_comment` · `get_all_column_comments` |
 | Query | `execute_sql`（只接受 SELECT / WITH） |
-| Setup（v0.7.0 起） | `setup_via_dialog` —— 在 session 內 bootstrap profile；密碼用 OS 原生對話框收集，**完全不過 MCP wire** |
+| Setup（v0.7.0 起） | `setup_via_dialog` —— 在 session 內 bootstrap profile；密碼用 OS 原生對話框收集，**完全不過 MCP wire**；宣告成功前先測試連線 · `get_setup_status` —— 唯讀設定狀態檢查；session 開始時可安全呼叫；**永不回傳密碼值** |
 
 每支 list / search 都有分頁；明確的 `WARNING` 字串會推 LLM 先讀註解
 再相信名字。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,4 +50,4 @@ redshift-comment-mcp = "redshift_comment_mcp.server:main"
 # .claude-plugin/plugin.json 的 "version" 欄位一同更新。
 [tool.setuptools_scm]
 write_to = "src/redshift_comment_mcp/_version.py"
-fallback_version = "0.6.0"
+fallback_version = "0.7.0"

--- a/src/redshift_comment_mcp/config.py
+++ b/src/redshift_comment_mcp/config.py
@@ -44,6 +44,16 @@ import tomli_w
 KEYRING_SERVICE = "redshift-comment-mcp"
 
 
+class ConfigurationError(ValueError):
+    """Raised when the resolved profile is missing fields or keychain password.
+
+    Subclasses ValueError so existing ``except ValueError`` clauses still catch
+    it (backward-compat). Downstream code that wants to react specifically to
+    "needs setup" — e.g. degraded-mode MCP tools that return a structured
+    not_configured error instead of raising — should catch this subclass.
+    """
+
+
 def config_path() -> Path:
     """Return the canonical config file path (XDG-compliant)."""
     xdg = os.environ.get("XDG_CONFIG_HOME") or str(Path.home() / ".config")

--- a/src/redshift_comment_mcp/redshift_tools.py
+++ b/src/redshift_comment_mcp/redshift_tools.py
@@ -19,17 +19,27 @@ def _not_configured_error(exc: ConfigurationError) -> Dict[str, Any]:
     came up. Now the server boots regardless; each tool catches the error
     via ``@_guarded`` and returns this dict so the agent sees the setup
     pipeline in its tool-call result, not in a hard-to-reach client log.
+
+    Schema is aligned with setup_via_dialog's error responses:
+    ``exception_class`` carries the type name for agents that want to
+    branch on it; ``message`` carries the raw exception text (this is
+    safe here because the ConfigurationError text is server-controlled
+    in resolve_connection_params — no third-party data flows into it).
     """
     return {
         "error": "not_configured",
+        "exception_class": type(exc).__name__,
         "message": str(exc),
         "next_step": (
-            "Call the `setup_via_dialog` MCP tool to bootstrap a profile "
-            "from within this session (host/port/user/dbname go via tool "
-            "args; password collected via OS-native dialog server-side and "
-            "never crosses the MCP wire). Alternatively, have the user run "
+            "1) Call `get_setup_status` to see the current state (whether "
+            "config.toml fields exist + whether a keychain password exists). "
+            "2) Call `setup_via_dialog(host=..., user=..., dbname=...)` to "
+            "bootstrap or update a profile — password collected via OS-"
+            "native dialog server-side, never crosses MCP wire / chat / "
+            "tool args. Alternatively, have the user run "
             "`uvx redshift-comment-mcp setup` in a terminal. After setup, "
-            "retry this tool — no MCP client restart needed (lazy resolve)."
+            "retry the original tool — no MCP client restart needed "
+            "(lazy resolve picks up the new profile on next call)."
         ),
     }
 
@@ -53,6 +63,112 @@ def _guarded(tool_fn):
         except ConfigurationError as e:
             return _not_configured_error(e)
     return wrapper
+
+
+# ===== setup_via_dialog response builders =====
+#
+# Each function builds a structured response for one of the dialog-collection
+# outcomes (cancelled / permission_denied / dialog_unavailable / platform_
+# unsupported / empty_password). Extracted to module level so the
+# setup_via_dialog tool body stays focused on orchestration; each builder
+# is self-contained, has only ``profile`` + ``platform`` inputs, and is
+# unit-testable independently of the larger tool flow.
+
+
+def _build_dialog_cancelled_response(profile: str, **_kw) -> Dict[str, Any]:
+    return {
+        "status": "dialog_cancelled",
+        "profile": profile,
+        "message": (
+            f"Password dialog was cancelled. Profile '{profile}' is "
+            f"INCOMPLETE — DB tools will continue to return not_configured "
+            f"until a password is set. Ask the user explicitly whether they "
+            f"intended to cancel (and abandon Redshift setup) or hit Cancel "
+            f"by accident; default to retrying setup_via_dialog if no clear "
+            f"cancellation signal was given."
+        ),
+    }
+
+
+def _build_permission_denied_response(profile: str, platform: str, **_kw) -> Dict[str, Any]:
+    return {
+        "status": "permission_denied",
+        "profile": profile,
+        "platform": platform,
+        "message": (
+            f"macOS blocked the password dialog. The app running the MCP "
+            f"server (Claude Desktop / Cursor / etc.) doesn't have "
+            f"`Automation > System Events` permission, so the dialog never "
+            f"appeared — this is NOT a user cancellation. Profile "
+            f"'{profile}' fields are saved but password is not set. Tell "
+            f"the user: open System Settings → Privacy & Security → "
+            f"Automation → find the app entry → enable `System Events`, "
+            f"then call setup_via_dialog again. If no permission entry "
+            f"exists yet, run `tccutil reset AppleEvents` from a terminal "
+            f"to force a fresh permission prompt on next attempt. Fallback: "
+            f"have the user pipe the password via "
+            f"`redshift-comment-mcp set-password --profile {profile} "
+            f"--stdin` from a terminal."
+        ),
+    }
+
+
+def _build_dialog_unavailable_response(profile: str, platform: str, **_kw) -> Dict[str, Any]:
+    return {
+        "status": "dialog_unavailable",
+        "profile": profile,
+        "platform": platform,
+        "message": (
+            f"No supported dialog tool found on this host (macOS needs "
+            f"`osascript`, Linux needs `zenity`). Profile fields for "
+            f"'{profile}' are saved but no password is set. Tell the user "
+            f"the dialog isn't available and instruct them to run this in "
+            f"a terminal themselves: `redshift-comment-mcp set-password "
+            f"--profile {profile} --stdin` (piping the password). DO NOT "
+            f"pass the password as a tool argument or shell argument — "
+            f"that leaks it to chat / process args / shell history."
+        ),
+    }
+
+
+def _build_platform_unsupported_response(profile: str, platform: str, **_kw) -> Dict[str, Any]:
+    return {
+        "status": "platform_unsupported",
+        "profile": profile,
+        "platform": platform,
+        "message": (
+            f"Password dialog is not supported on platform '{platform}' "
+            f"(only macOS and Linux are wired). Profile fields for "
+            f"'{profile}' are saved but no password is set. Tell the user "
+            f"to set the password from their terminal: "
+            f"`redshift-comment-mcp set-password --profile {profile} "
+            f"--stdin` (pipe the password via stdin)."
+        ),
+    }
+
+
+def _build_empty_password_response(profile: str, **_kw) -> Dict[str, Any]:
+    return {
+        "status": "empty_password",
+        "profile": profile,
+        "message": (
+            f"Password dialog returned an empty string — likely the user "
+            f"clicked OK without typing, or the dialog failed to render. "
+            f"Profile '{profile}' is INCOMPLETE. Ask the user to retry "
+            f"and call setup_via_dialog again with the same arguments."
+        ),
+    }
+
+
+# Dispatch table for setup_via_dialog's 4 ``reason``-based failure paths
+# returned by ``_collect_password_via_dialog``. The 5th case (``ok`` but
+# empty password) is checked separately because it isn't keyed by reason.
+_DIALOG_FAILURE_BUILDERS: Dict[str, Callable[..., Dict[str, Any]]] = {
+    "cancelled": _build_dialog_cancelled_response,
+    "permission_denied": _build_permission_denied_response,
+    "unavailable": _build_dialog_unavailable_response,
+    "unsupported": _build_platform_unsupported_response,
+}
 
 # 分頁設定
 DEFAULT_MAX_ITEMS = 50  # 預設最大回傳筆數（超過時自動截斷）
@@ -1206,88 +1322,16 @@ the only chat-leak-free paths.
 
             password, reason = _collect_password_via_dialog(profile)
 
-            if reason == "cancelled":
-                return {
-                    "status": "dialog_cancelled",
-                    "profile": profile,
-                    "message": (
-                        f"Password dialog was cancelled. Profile '{profile}' "
-                        f"is INCOMPLETE — DB tools will continue to return "
-                        f"not_configured until a password is set. Ask the "
-                        f"user explicitly whether they intended to cancel "
-                        f"(and abandon Redshift setup) or hit Cancel by "
-                        f"accident; default to retrying setup_via_dialog "
-                        f"if no clear cancellation signal was given."
-                    ),
-                }
-            if reason == "permission_denied":
-                return {
-                    "status": "permission_denied",
-                    "profile": profile,
-                    "platform": _sys.platform,
-                    "message": (
-                        f"macOS blocked the password dialog. The app "
-                        f"running the MCP server (Claude Desktop / Cursor "
-                        f"/ etc.) doesn't have `Automation > System Events` "
-                        f"permission, so the dialog never appeared — this "
-                        f"is NOT a user cancellation. Profile '{profile}' "
-                        f"fields are saved but password is not set. Tell "
-                        f"the user: open System Settings → Privacy & "
-                        f"Security → Automation → find the app entry → "
-                        f"enable `System Events`, then call setup_via_dialog "
-                        f"again. If no permission entry exists yet, run "
-                        f"`tccutil reset AppleEvents` from a terminal to "
-                        f"force a fresh permission prompt on next attempt. "
-                        f"Fallback: have the user pipe the password via "
-                        f"`redshift-comment-mcp set-password --profile "
-                        f"{profile} --stdin` from a terminal."
-                    ),
-                }
-            if reason == "unavailable":
-                return {
-                    "status": "dialog_unavailable",
-                    "profile": profile,
-                    "platform": _sys.platform,
-                    "message": (
-                        f"No supported dialog tool found on this host "
-                        f"(macOS needs `osascript`, Linux needs `zenity`). "
-                        f"Profile fields for '{profile}' are saved but no "
-                        f"password is set. Tell the user the dialog isn't "
-                        f"available and instruct them to run this in a "
-                        f"terminal themselves: `redshift-comment-mcp "
-                        f"set-password --profile {profile} --stdin` (piping "
-                        f"the password). DO NOT pass the password as a tool "
-                        f"argument or shell argument — that leaks it to "
-                        f"chat / process args / shell history."
-                    ),
-                }
-            if reason == "unsupported":
-                return {
-                    "status": "platform_unsupported",
-                    "profile": profile,
-                    "platform": _sys.platform,
-                    "message": (
-                        f"Password dialog is not supported on platform "
-                        f"'{_sys.platform}' (only macOS and Linux are "
-                        f"wired). Profile fields for '{profile}' are saved "
-                        f"but no password is set. Tell the user to set the "
-                        f"password from their terminal: `redshift-comment-"
-                        f"mcp set-password --profile {profile} --stdin` "
-                        f"(pipe the password via stdin)."
-                    ),
-                }
+            # 4 reason-keyed failure paths dispatch to module-level builders
+            # (see _DIALOG_FAILURE_BUILDERS). The 5th case ("ok" reason but
+            # empty password — user clicked OK without typing) is checked
+            # separately because it's keyed by password emptiness, not reason.
+            if reason in _DIALOG_FAILURE_BUILDERS:
+                return _DIALOG_FAILURE_BUILDERS[reason](
+                    profile=profile, platform=_sys.platform,
+                )
             if not password:
-                return {
-                    "status": "empty_password",
-                    "profile": profile,
-                    "message": (
-                        f"Password dialog returned an empty string — likely "
-                        f"the user clicked OK without typing, or the dialog "
-                        f"failed to render. Profile '{profile}' is "
-                        f"INCOMPLETE. Ask the user to retry and call "
-                        f"setup_via_dialog again with the same arguments."
-                    ),
-                }
+                return _build_empty_password_response(profile=profile)
 
             try:
                 cfg.set_password(profile, password)

--- a/src/redshift_comment_mcp/redshift_tools.py
+++ b/src/redshift_comment_mcp/redshift_tools.py
@@ -396,6 +396,11 @@ Either way, the bootstrap flow is:
        setup_via_dialog again with corrections (overwrites).
      - `dialog_cancelled` / `empty_password` — profile incomplete;
        ask the user whether they meant to cancel; usually retry.
+     - `permission_denied` (macOS only) — Apple Events blocked. The
+       dialog never appeared; the MCP-client app lacks Automation >
+       System Events permission. Do NOT retry blindly — tell the user
+       to enable it (System Settings → Privacy & Security → Automation)
+       OR fall back to `set-password --stdin` from a terminal.
      - `dialog_unavailable` / `platform_unsupported` (no GUI tool) —
        the dialog path is unusable on this host; tell the user to
        run `redshift-comment-mcp set-password --profile X --stdin`
@@ -1177,6 +1182,29 @@ the only chat-leak-free paths.
                         f"(and abandon Redshift setup) or hit Cancel by "
                         f"accident; default to retrying setup_via_dialog "
                         f"if no clear cancellation signal was given."
+                    ),
+                }
+            if reason == "permission_denied":
+                return {
+                    "status": "permission_denied",
+                    "profile": profile,
+                    "platform": _sys.platform,
+                    "message": (
+                        f"macOS blocked the password dialog. The app "
+                        f"running the MCP server (Claude Desktop / Cursor "
+                        f"/ etc.) doesn't have `Automation > System Events` "
+                        f"permission, so the dialog never appeared — this "
+                        f"is NOT a user cancellation. Profile '{profile}' "
+                        f"fields are saved but password is not set. Tell "
+                        f"the user: open System Settings → Privacy & "
+                        f"Security → Automation → find the app entry → "
+                        f"enable `System Events`, then call setup_via_dialog "
+                        f"again. If no permission entry exists yet, run "
+                        f"`tccutil reset AppleEvents` from a terminal to "
+                        f"force a fresh permission prompt on next attempt. "
+                        f"Fallback: have the user pipe the password via "
+                        f"`redshift-comment-mcp set-password --profile "
+                        f"{profile} --stdin` from a terminal."
                     ),
                 }
             if reason == "unavailable":

--- a/src/redshift_comment_mcp/redshift_tools.py
+++ b/src/redshift_comment_mcp/redshift_tools.py
@@ -1,11 +1,58 @@
+import functools
 import logging
 import re
 import awswrangler as wr
 from fastmcp import FastMCP
-from typing import Dict, Any, Optional
+from typing import Any, Callable, Dict, Optional
+from .config import ConfigurationError
 from .connection import RedshiftConnectionConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _not_configured_error(exc: ConfigurationError) -> Dict[str, Any]:
+    """Structured response surfaced to the agent when a DB tool is invoked
+    on a server without a configured profile (degraded-mode contract).
+
+    Replaces the pre-v0.7.0 behavior of letting the ConfigurationError
+    propagate up out of ``main()`` and crash the server before MCP wire even
+    came up. Now the server boots regardless; each tool catches the error
+    via ``@_guarded`` and returns this dict so the agent sees the setup
+    pipeline in its tool-call result, not in a hard-to-reach client log.
+    """
+    return {
+        "error": "not_configured",
+        "message": str(exc),
+        "next_step": (
+            "Call the `setup_via_dialog` MCP tool to bootstrap a profile "
+            "from within this session (host/port/user/dbname go via tool "
+            "args; password collected via OS-native dialog server-side and "
+            "never crosses the MCP wire). Alternatively, have the user run "
+            "`uvx redshift-comment-mcp setup` in a terminal. After setup, "
+            "retry this tool — no MCP client restart needed (lazy resolve)."
+        ),
+    }
+
+
+def _guarded(tool_fn):
+    """Decorator: convert ConfigurationError into a structured tool response.
+
+    Stack with ``@self.mcp.tool`` immediately above:
+
+        @self.mcp.tool
+        @_guarded
+        def list_schemas(...): ...
+
+    Other exceptions propagate to FastMCP for normal error handling — only
+    "no profile yet" gets the in-band degraded-mode response.
+    """
+    @functools.wraps(tool_fn)
+    def wrapper(*args, **kwargs):
+        try:
+            return tool_fn(*args, **kwargs)
+        except ConfigurationError as e:
+            return _not_configured_error(e)
+    return wrapper
 
 # 分頁設定
 DEFAULT_MAX_ITEMS = 50  # 預設最大回傳筆數（超過時自動截斷）
@@ -260,8 +307,19 @@ class RedshiftTools:
     Provides a set of tools for interacting with Redshift databases to support guided data exploration.
     Uses a connect/disconnect pattern for each operation to ensure maximum robustness.
     """
-    def __init__(self, connection_config: RedshiftConnectionConfig):
-        self.config = connection_config
+    def __init__(self, config_provider: Callable[[], RedshiftConnectionConfig]):
+        """Construct a tool provider with a *lazy* connection-config resolver.
+
+        ``config_provider`` is called on every DB tool invocation (via the
+        ``config`` property below). It re-reads config.toml + keychain each
+        time, so a profile newly written by ``setup_via_dialog`` /
+        ``setup`` CLI is picked up on the next tool call without restarting
+        the MCP client. If the provider raises ``ConfigurationError``, the
+        ``@_guarded`` decorator on each tool turns it into a structured
+        ``{"error": "not_configured", ...}`` response — the server itself
+        never crashes for missing-profile.
+        """
+        self._config_provider = config_provider
         self.mcp = FastMCP(
             name="Redshift Comment MCP",
             instructions="""
@@ -309,9 +367,44 @@ paraphrase, summarize, or hide the query. Users need direct visibility
 into what runs against their database. The metadata tools (list_* /
 search_* / get_*) use fixed catalog templates and do not carry these
 fields; their semantic API is the contract.
+
+SETUP RECOVERY (degraded-mode contract, since v0.7.0): The server can
+boot without a configured profile. If any DB tool returns
+`{"error": "not_configured", ...}`, the profile / keychain are missing.
+DO NOT keep retrying — read the `next_step` field and act:
+
+  1. Ask the user for host / port / user / dbname conversationally
+     (these are NOT secrets; OK to discuss in chat).
+  2. Call the `setup_via_dialog` MCP tool with those args. The tool
+     writes config.toml fields and then launches an OS-native password
+     dialog server-side. The password value never crosses the MCP wire.
+  3. On `{"status": "configured", ...}`, retry the original DB tool —
+     lazy resolution picks up the new profile without an MCP client
+     restart.
+  4. If `setup_via_dialog` returns dialog_unavailable / platform_
+     unsupported (no GUI), have the user run
+     `redshift-comment-mcp set-password --profile X --stdin` from a
+     terminal instead.
+
+Never invent host/user/dbname values. Never pass the password as a
+tool argument or shell argument — the system dialog or stdin pipe are
+the only chat-leak-free paths.
 """
         )
         self._setup_tools()
+
+    @property
+    def config(self) -> RedshiftConnectionConfig:
+        """Lazy-resolved current connection config.
+
+        Each access invokes ``self._config_provider()``, which re-runs
+        ``resolve_connection_params`` against current CLI args + on-disk
+        state (config.toml + active-profile pointer file + keychain).
+        Raises ``ConfigurationError`` when no profile is configured —
+        caught by ``@_guarded`` on each tool so the server returns a
+        structured response instead of crashing.
+        """
+        return self._config_provider()
 
     def _setup_tools(self):
         """設定所有 MCP 工具"""
@@ -319,6 +412,7 @@ fields; their semantic API is the contract.
         # ========== 列表工具 ==========
 
         @self.mcp.tool
+        @_guarded
         def list_schemas(limit: Optional[int] = None, offset: int = 0, include_comments: bool = True) -> Dict[str, Any]:
             """List schema names. include_comments defaults to True (cheap — schema count is small)."""
             if include_comments:
@@ -364,6 +458,7 @@ fields; their semantic API is the contract.
             return result
 
         @self.mcp.tool
+        @_guarded
         def list_tables(schema_name: str, limit: Optional[int] = None, offset: int = 0, include_comments: bool = False, include_parent_comments: bool = True) -> Dict[str, Any]:
             """List tables in a schema. Pass include_comments=True to include table comments inline; include_parent_comments (default True) also returns the parent schema's comment."""
             if not schema_name or not schema_name.isidentifier():
@@ -457,6 +552,7 @@ fields; their semantic API is the contract.
             return result
 
         @self.mcp.tool
+        @_guarded
         def list_columns(schema_name: str, table_name: str, limit: Optional[int] = None, offset: int = 0, include_comments: bool = False, include_parent_comments: bool = True) -> Dict[str, Any]:
             """List columns (name, type, nullable) in a table. Pass include_comments=True to include column comments inline; include_parent_comments (default True) also returns the parent table's comment."""
             if not schema_name.isidentifier() or not table_name.isidentifier():
@@ -552,6 +648,7 @@ fields; their semantic API is the contract.
         # ========== 搜尋工具 ==========
 
         @self.mcp.tool
+        @_guarded
         def search_schemas(keywords: str, limit: Optional[int] = None, offset: int = 0) -> Dict[str, Any]:
             """Search schemas by keywords (space-separated, OR logic) over schema name and comment."""
             # 解析關鍵字
@@ -618,6 +715,7 @@ fields; their semantic API is the contract.
             return result
 
         @self.mcp.tool
+        @_guarded
         def search_tables(keywords: str, schema_name: Optional[str] = None, limit: Optional[int] = None, offset: int = 0) -> Dict[str, Any]:
             """Search tables by keywords (space-separated, OR logic) over table name and comment.
 
@@ -713,6 +811,7 @@ fields; their semantic API is the contract.
             return result
 
         @self.mcp.tool
+        @_guarded
         def search_columns(keywords: str, schema_name: str, table_name: Optional[str] = None, limit: Optional[int] = None, offset: int = 0) -> Dict[str, Any]:
             """Search columns by keywords (space-separated, OR logic) over column name and comment.
 
@@ -819,6 +918,7 @@ fields; their semantic API is the contract.
         # ========== 註解查詢工具 ==========
 
         @self.mcp.tool
+        @_guarded
         def get_schema_comment(schema_name: str) -> Dict[str, Any]:
             """Get the authoritative comment for a schema — defines its true business purpose; trust it over the schema name."""
             if not schema_name or not schema_name.isidentifier():
@@ -843,6 +943,7 @@ fields; their semantic API is the contract.
             }
 
         @self.mcp.tool
+        @_guarded
         def get_table_comment(schema_name: str, table_name: str) -> Dict[str, Any]:
             """Get the authoritative comment for a table — defines what data it actually contains; trust it over the table name."""
             if not schema_name.isidentifier() or not table_name.isidentifier():
@@ -869,6 +970,7 @@ fields; their semantic API is the contract.
             }
 
         @self.mcp.tool
+        @_guarded
         def get_column_comment(schema_name: str, table_name: str, column_name: str) -> Dict[str, Any]:
             """Get the authoritative comment for a column — defines its business meaning and calculation logic; trust it over the column name."""
             if not schema_name.isidentifier() or not table_name.isidentifier():
@@ -899,6 +1001,7 @@ fields; their semantic API is the contract.
             }
 
         @self.mcp.tool
+        @_guarded
         def get_all_column_comments(schema_name: str, table_name: str, limit: Optional[int] = None, offset: int = 0) -> Dict[str, Any]:
             """Get authoritative comments for ALL columns in a table at once. Each comment overrides the column name."""
             if not schema_name.isidentifier() or not table_name.isidentifier():
@@ -953,12 +1056,18 @@ fields; their semantic API is the contract.
         # ========== SQL 執行工具 ==========
 
         @self.mcp.tool
+        @_guarded
         def execute_sql(sql_statement: str, limit: Optional[int] = None, offset: int = 0) -> Dict[str, Any]:
             """Execute a read-only SQL query (SELECT/WITH only). Result rows are paginated via limit/offset."""
             validate_read_only_sql(sql_statement)
 
+            # Hoist config access out of the try/except below so ConfigurationError
+            # (raised by the lazy provider when no profile is set) propagates up to
+            # @_guarded instead of getting rewrapped as a generic SQL error.
+            config = self.config
+
             try:
-                with self.config.get_connection() as conn:
+                with config.get_connection() as conn:
                     df = wr.redshift.read_sql_query(sql_statement, con=conn)
                     records = df.to_dict(orient='records')
                     columns = list(df.columns)
@@ -989,6 +1098,128 @@ fields; their semantic API is the contract.
             except Exception as e:
                 logger.error(f"SQL execution failed: {sql_statement}", exc_info=True)
                 raise ValueError(f"SQL execution error. Please check your syntax. Original error: {e}")
+
+        # ========== Setup tool (control plane — works WITHOUT a configured profile) ==========
+
+        @self.mcp.tool
+        def setup_via_dialog(
+            host: str,
+            user: str,
+            dbname: str,
+            profile: str = "default",
+            port: int = 5439,
+        ) -> Dict[str, Any]:
+            """Bootstrap (or update) a Redshift connection profile from inside an MCP session.
+
+            Use when DB tools (list_schemas etc.) return ``{"error": "not_configured"}``,
+            or to add a new profile / re-key an existing one. Ask the user for
+            host / port / user / dbname conversationally — these are not secret —
+            then call this tool. The password is collected via an OS-native
+            dialog (macOS osascript / Linux zenity) launched server-side; it
+            **never crosses the MCP wire, never appears in chat or tool args**.
+
+            Outcomes (return shape):
+              - ``{"status": "configured", ...}`` — profile written, password in
+                keychain. Lazy resolve picks it up on next DB tool call; no
+                restart needed.
+              - ``{"status": "dialog_cancelled" | "dialog_unavailable" |
+                   "platform_unsupported" | "empty_password", ...}`` — profile
+                fields saved but no password set; the message field tells the
+                agent / user what to do next (often: run
+                ``redshift-comment-mcp set-password --profile X --stdin`` from
+                a terminal).
+
+            For headless environments without a GUI, prefer the CLI pair
+            ``set-fields`` + ``set-password --stdin`` instead.
+            """
+            import sys as _sys
+            from . import config as cfg
+            from .setup_cli import _collect_password_via_dialog
+
+            if not all([host, user, dbname]):
+                return {
+                    "error": "missing_field",
+                    "message": "host, user, and dbname are all required.",
+                }
+
+            try:
+                cfg.write_profile(profile, host=host, port=port, user=user, dbname=dbname)
+            except Exception as e:
+                logger.error(f"setup_via_dialog: write_profile failed: {e}", exc_info=True)
+                return {"error": "write_profile_failed", "message": str(e)}
+
+            password, reason = _collect_password_via_dialog(profile)
+
+            if reason == "cancelled":
+                return {
+                    "status": "dialog_cancelled",
+                    "profile": profile,
+                    "message": (
+                        f"Password dialog was cancelled. Profile fields for "
+                        f"'{profile}' are saved to config.toml but no password "
+                        f"is set. Retry setup_via_dialog, or have the user run "
+                        f"`redshift-comment-mcp set-password --profile "
+                        f"{profile} --dialog` later."
+                    ),
+                }
+            if reason == "unavailable":
+                return {
+                    "status": "dialog_unavailable",
+                    "profile": profile,
+                    "platform": _sys.platform,
+                    "message": (
+                        f"No supported dialog tool installed (macOS needs "
+                        f"`osascript`, Linux needs `zenity`). Profile fields "
+                        f"for '{profile}' are saved; have the user pipe the "
+                        f"password via `redshift-comment-mcp set-password "
+                        f"--profile {profile} --stdin` from a terminal."
+                    ),
+                }
+            if reason == "unsupported":
+                return {
+                    "status": "platform_unsupported",
+                    "profile": profile,
+                    "platform": _sys.platform,
+                    "message": (
+                        f"Password dialog is not supported on platform "
+                        f"'{_sys.platform}' (only macOS and Linux are wired). "
+                        f"Profile fields for '{profile}' are saved; use the "
+                        f"`set-password --stdin` CLI subcommand to set the "
+                        f"password via stdin pipe."
+                    ),
+                }
+            if not password:
+                return {
+                    "status": "empty_password",
+                    "profile": profile,
+                    "message": (
+                        f"Password dialog returned an empty string. "
+                        f"Profile fields for '{profile}' are saved; retry "
+                        f"setup_via_dialog or run set-password manually."
+                    ),
+                }
+
+            try:
+                cfg.set_password(profile, password)
+            except Exception as e:
+                logger.error(f"setup_via_dialog: set_password failed: {e}", exc_info=True)
+                return {"error": "keychain_write_failed", "message": str(e)}
+
+            return {
+                "status": "configured",
+                "profile": profile,
+                "host": host,
+                "port": port,
+                "user": user,
+                "dbname": dbname,
+                "message": (
+                    f"Profile '{profile}' configured. Fields written to "
+                    f"~/.config/redshift-comment-mcp/config.toml, password "
+                    f"stored in OS keychain. Retry any DB tool now — lazy "
+                    f"resolution will pick up the new profile on next call "
+                    f"without restarting the MCP client."
+                ),
+            }
 
     def get_server(self):
         """取得配置好的 MCP 伺服器"""

--- a/src/redshift_comment_mcp/redshift_tools.py
+++ b/src/redshift_comment_mcp/redshift_tools.py
@@ -1120,6 +1120,24 @@ the only chat-leak-free paths.
                 raise ValueError(f"SQL execution error. Please check your syntax. Original error: {e}")
 
         # ========== Setup tool (control plane — works WITHOUT a configured profile) ==========
+        #
+        # `setup_via_dialog` and `get_setup_status` below INTENTIONALLY skip
+        # the `@_guarded` decorator that wraps every DB tool above. The
+        # decorator converts `ConfigurationError` → not_configured response,
+        # but these two tools must be USABLE when no profile is configured
+        # yet — that's literally their job. Wrapping them in @_guarded would
+        # make them refuse to run in the very state where they're needed.
+        # Adding the decorator here is a regression that the existing
+        # behavioral tests (test_setup_via_dialog_works_without_configured_
+        # profile, test_get_setup_status_works_in_degraded_mode) catch.
+        #
+        # Forward look: the MCP 2026-07-28 RC introduces `Elicitation` —
+        # a primitive for servers to request direct user input via the
+        # client's native UI. Once GA'd (and FastMCP exposes it), the
+        # subprocess+osascript dialog hack here becomes obsolete: server
+        # can request a password through the protocol and the client
+        # presents a native secure input widget. Until then, this is the
+        # chat-leak-free path that works with current MCP spec.
 
         @self.mcp.tool
         def setup_via_dialog(
@@ -1165,8 +1183,26 @@ the only chat-leak-free paths.
             try:
                 cfg.write_profile(profile, host=host, port=port, user=user, dbname=dbname)
             except Exception as e:
+                # Per CWE-209 / OWASP Error Handling Cheat Sheet: log the
+                # full exception server-side, but return only the exception
+                # CLASS to the client. The class name is diagnostic-useful
+                # (PermissionError vs OSError vs ...) without including any
+                # exception args, which could in theory carry sensitive
+                # info (file paths, environment values, etc.).
                 logger.error(f"setup_via_dialog: write_profile failed: {e}", exc_info=True)
-                return {"error": "write_profile_failed", "message": str(e)}
+                return {
+                    "error": "write_profile_failed",
+                    "exception_class": type(e).__name__,
+                    "message": (
+                        f"Failed to write profile fields to config.toml "
+                        f"(exception class: {type(e).__name__}). The "
+                        f"underlying error was logged server-side with "
+                        f"full detail; it is not included in this response "
+                        f"to avoid leaking sensitive context through the "
+                        f"MCP wire. Most likely causes: config directory "
+                        f"not writable, disk full, or filesystem error."
+                    ),
+                }
 
             password, reason = _collect_password_via_dialog(profile)
 
@@ -1256,8 +1292,37 @@ the only chat-leak-free paths.
             try:
                 cfg.set_password(profile, password)
             except Exception as e:
+                # Same CWE-209 discipline as write_profile_failed above: log
+                # full exception server-side, return only the exception
+                # class name + a sanitized message. Keychain backends are
+                # third-party (macOS Security framework, gnome-keyring,
+                # KWallet, etc.) and their exception args' contents are
+                # outside our control — assume they may carry context we
+                # don't want crossing the MCP wire.
                 logger.error(f"setup_via_dialog: set_password failed: {e}", exc_info=True)
-                return {"error": "keychain_write_failed", "message": str(e)}
+                # Surface specific keyring exceptions when recognisable
+                # (per Snyk guidance: catch keyring.errors.PasswordSetError
+                # / KeyringLocked separately for more actionable diagnosis).
+                exc_class = type(e).__name__
+                hint = {
+                    "PasswordSetError": "Keychain rejected the write (locked, missing entitlement, or backend refused).",
+                    "KeyringLocked": "OS keychain is currently locked; unlock it and retry.",
+                    "InitError": "Keyring backend failed to initialize on this host.",
+                    "NoKeyringError": "No keyring backend is available on this host.",
+                }.get(exc_class, "Underlying keychain write failed.")
+                return {
+                    "error": "keychain_write_failed",
+                    "exception_class": exc_class,
+                    "message": (
+                        f"{hint} Profile '{profile}' fields were saved to "
+                        f"config.toml but the password was NOT stored. The "
+                        f"underlying error was logged server-side with full "
+                        f"detail; it is not included here per chat-leak "
+                        f"hygiene. Have the user pipe the password via "
+                        f"`redshift-comment-mcp set-password --profile "
+                        f"{profile} --stdin` from a terminal as a fallback."
+                    ),
+                }
 
             # Verify the freshly-written profile actually connects to Redshift
             # before declaring success. Catches typos / VPN-not-connected /

--- a/src/redshift_comment_mcp/redshift_tools.py
+++ b/src/redshift_comment_mcp/redshift_tools.py
@@ -369,22 +369,37 @@ search_* / get_*) use fixed catalog templates and do not carry these
 fields; their semantic API is the contract.
 
 SETUP RECOVERY (degraded-mode contract, since v0.7.0): The server can
-boot without a configured profile. If any DB tool returns
-`{"error": "not_configured", ...}`, the profile / keychain are missing.
-DO NOT keep retrying — read the `next_step` field and act:
+boot without a configured profile. Two entry points:
+
+  - PROACTIVE: call `get_setup_status` at session start to check whether
+    a profile is configured. Safe to call any time, returns
+    non-secrets only. If `configured=false`, follow `next_step`.
+  - REACTIVE: any DB tool returns `{"error": "not_configured", ...}` —
+    read the `next_step` field and follow it.
+
+Either way, the bootstrap flow is:
 
   1. Ask the user for host / port / user / dbname conversationally
      (these are NOT secrets; OK to discuss in chat).
-  2. Call the `setup_via_dialog` MCP tool with those args. The tool
-     writes config.toml fields and then launches an OS-native password
-     dialog server-side. The password value never crosses the MCP wire.
-  3. On `{"status": "configured", ...}`, retry the original DB tool —
-     lazy resolution picks up the new profile without an MCP client
-     restart.
-  4. If `setup_via_dialog` returns dialog_unavailable / platform_
-     unsupported (no GUI), have the user run
-     `redshift-comment-mcp set-password --profile X --stdin` from a
-     terminal instead.
+  2. Call `setup_via_dialog` with those args. It writes config.toml
+     fields, launches an OS-native password dialog server-side
+     (macOS osascript / Linux zenity), and **tests the connection
+     against Redshift** before declaring success. The password value
+     never crosses the MCP wire.
+  3. Interpret the response status:
+     - `configured` (with `tested: true`) — retry the original DB
+       tool, lazy resolution picks up the new profile without restart.
+     - `configured_but_connection_failed` — fields/password were
+       saved but Redshift connect failed. Read `connection_error`
+       (likely host typo / VPN not connected / wrong password /
+       paused cluster), ask the user to verify, then call
+       setup_via_dialog again with corrections (overwrites).
+     - `dialog_cancelled` / `empty_password` — profile incomplete;
+       ask the user whether they meant to cancel; usually retry.
+     - `dialog_unavailable` / `platform_unsupported` (no GUI tool) —
+       the dialog path is unusable on this host; tell the user to
+       run `redshift-comment-mcp set-password --profile X --stdin`
+       from a terminal. DO NOT pass the password as a tool argument.
 
 Never invent host/user/dbname values. Never pass the password as a
 tool argument or shell argument — the system dialog or stdin pipe are
@@ -1155,11 +1170,13 @@ the only chat-leak-free paths.
                     "status": "dialog_cancelled",
                     "profile": profile,
                     "message": (
-                        f"Password dialog was cancelled. Profile fields for "
-                        f"'{profile}' are saved to config.toml but no password "
-                        f"is set. Retry setup_via_dialog, or have the user run "
-                        f"`redshift-comment-mcp set-password --profile "
-                        f"{profile} --dialog` later."
+                        f"Password dialog was cancelled. Profile '{profile}' "
+                        f"is INCOMPLETE — DB tools will continue to return "
+                        f"not_configured until a password is set. Ask the "
+                        f"user explicitly whether they intended to cancel "
+                        f"(and abandon Redshift setup) or hit Cancel by "
+                        f"accident; default to retrying setup_via_dialog "
+                        f"if no clear cancellation signal was given."
                     ),
                 }
             if reason == "unavailable":
@@ -1168,11 +1185,16 @@ the only chat-leak-free paths.
                     "profile": profile,
                     "platform": _sys.platform,
                     "message": (
-                        f"No supported dialog tool installed (macOS needs "
-                        f"`osascript`, Linux needs `zenity`). Profile fields "
-                        f"for '{profile}' are saved; have the user pipe the "
-                        f"password via `redshift-comment-mcp set-password "
-                        f"--profile {profile} --stdin` from a terminal."
+                        f"No supported dialog tool found on this host "
+                        f"(macOS needs `osascript`, Linux needs `zenity`). "
+                        f"Profile fields for '{profile}' are saved but no "
+                        f"password is set. Tell the user the dialog isn't "
+                        f"available and instruct them to run this in a "
+                        f"terminal themselves: `redshift-comment-mcp "
+                        f"set-password --profile {profile} --stdin` (piping "
+                        f"the password). DO NOT pass the password as a tool "
+                        f"argument or shell argument — that leaks it to "
+                        f"chat / process args / shell history."
                     ),
                 }
             if reason == "unsupported":
@@ -1182,10 +1204,12 @@ the only chat-leak-free paths.
                     "platform": _sys.platform,
                     "message": (
                         f"Password dialog is not supported on platform "
-                        f"'{_sys.platform}' (only macOS and Linux are wired). "
-                        f"Profile fields for '{profile}' are saved; use the "
-                        f"`set-password --stdin` CLI subcommand to set the "
-                        f"password via stdin pipe."
+                        f"'{_sys.platform}' (only macOS and Linux are "
+                        f"wired). Profile fields for '{profile}' are saved "
+                        f"but no password is set. Tell the user to set the "
+                        f"password from their terminal: `redshift-comment-"
+                        f"mcp set-password --profile {profile} --stdin` "
+                        f"(pipe the password via stdin)."
                     ),
                 }
             if not password:
@@ -1193,9 +1217,11 @@ the only chat-leak-free paths.
                     "status": "empty_password",
                     "profile": profile,
                     "message": (
-                        f"Password dialog returned an empty string. "
-                        f"Profile fields for '{profile}' are saved; retry "
-                        f"setup_via_dialog or run set-password manually."
+                        f"Password dialog returned an empty string — likely "
+                        f"the user clicked OK without typing, or the dialog "
+                        f"failed to render. Profile '{profile}' is "
+                        f"INCOMPLETE. Ask the user to retry and call "
+                        f"setup_via_dialog again with the same arguments."
                     ),
                 }
 
@@ -1205,6 +1231,37 @@ the only chat-leak-free paths.
                 logger.error(f"setup_via_dialog: set_password failed: {e}", exc_info=True)
                 return {"error": "keychain_write_failed", "message": str(e)}
 
+            # Verify the freshly-written profile actually connects to Redshift
+            # before declaring success. Catches typos / VPN-not-connected /
+            # firewall / wrong password / paused-cluster early so the agent
+            # doesn't claim "configured" then immediately fail on the next
+            # DB tool call.
+            from .setup_cli import _test_redshift_connection
+            ok, conn_err = _test_redshift_connection(host, port, user, password, dbname)
+
+            if not ok:
+                return {
+                    "status": "configured_but_connection_failed",
+                    "profile": profile,
+                    "host": host,
+                    "port": port,
+                    "user": user,
+                    "dbname": dbname,
+                    "tested": False,
+                    "connection_error": conn_err,
+                    "message": (
+                        f"Profile '{profile}' fields and password were "
+                        f"saved, but the test connection to Redshift "
+                        f"FAILED. The most likely causes: wrong host (typo "
+                        f"or VPN not connected), wrong port, wrong "
+                        f"user/password, firewall block, or the cluster "
+                        f"is paused. Verify the values with the user and "
+                        f"call setup_via_dialog again with corrections "
+                        f"(it will overwrite). Connection error attached "
+                        f"in `connection_error` field."
+                    ),
+                }
+
             return {
                 "status": "configured",
                 "profile": profile,
@@ -1212,14 +1269,80 @@ the only chat-leak-free paths.
                 "port": port,
                 "user": user,
                 "dbname": dbname,
+                "tested": True,
                 "message": (
-                    f"Profile '{profile}' configured. Fields written to "
-                    f"~/.config/redshift-comment-mcp/config.toml, password "
-                    f"stored in OS keychain. Retry any DB tool now — lazy "
-                    f"resolution will pick up the new profile on next call "
-                    f"without restarting the MCP client."
+                    f"Profile '{profile}' configured AND test connection "
+                    f"succeeded. Fields written to ~/.config/redshift-"
+                    f"comment-mcp/config.toml, password stored in OS "
+                    f"keychain, SELECT 1 against Redshift returned OK. "
+                    f"Retry any DB tool now — lazy resolution will pick "
+                    f"up the new profile on next call without restarting "
+                    f"the MCP client."
                 ),
             }
+
+        @self.mcp.tool
+        def get_setup_status(profile: str = "default") -> Dict[str, Any]:
+            """Read-only check of whether a profile is configured. Safe to
+            call at any time including the very start of a session — does
+            not touch Redshift, does not return any secrets.
+
+            Use at session start to decide proactively whether to call
+            ``setup_via_dialog`` (before triggering any DB tool's
+            not_configured error path), or to verify a setup_via_dialog
+            call succeeded from a fresh angle.
+
+            Returns:
+              - ``profile`` — the queried profile name
+              - ``configured`` — bool, equivalent to has_fields && has_password
+              - ``has_fields`` — whether config.toml has this profile's
+                non-secret fields (host / port / user / dbname)
+              - ``has_password`` — whether the OS keychain has a password
+                for this profile (NEVER returns the password itself)
+              - ``host`` / ``port`` / ``user`` / ``dbname`` — present only
+                when has_fields=True (these are non-secret)
+              - ``next_step`` — present only when configured=False;
+                actionable hint pointing at setup_via_dialog
+            """
+            from . import config as cfg
+
+            profile_data = cfg.read_profile(profile)
+            has_fields = profile_data is not None
+            has_password = cfg.get_password(profile) is not None
+
+            result: Dict[str, Any] = {
+                "profile": profile,
+                "configured": has_fields and has_password,
+                "has_fields": has_fields,
+                "has_password": has_password,
+            }
+
+            if has_fields:
+                # Non-secret — safe to expose. Lets the agent show the user
+                # what's currently set up vs. what they're about to overwrite.
+                result["host"] = profile_data["host"]
+                result["port"] = profile_data["port"]
+                result["user"] = profile_data["user"]
+                result["dbname"] = profile_data["dbname"]
+
+            if not result["configured"]:
+                if not has_fields:
+                    result["next_step"] = (
+                        f"Profile '{profile}' has no config.toml entry. "
+                        f"Call setup_via_dialog(host=..., user=..., "
+                        f"dbname=...) to provision it. Ask the user for "
+                        f"host/user/dbname conversationally — these are "
+                        f"not secrets."
+                    )
+                else:
+                    result["next_step"] = (
+                        f"Profile '{profile}' has fields but no password "
+                        f"in keychain. Call setup_via_dialog with the "
+                        f"existing values (or different ones to overwrite) "
+                        f"— the dialog will collect a password and store it."
+                    )
+
+            return result
 
     def get_server(self):
         """取得配置好的 MCP 伺服器"""

--- a/src/redshift_comment_mcp/redshift_tools.py
+++ b/src/redshift_comment_mcp/redshift_tools.py
@@ -1291,8 +1291,15 @@ the only chat-leak-free paths.
             from .setup_cli import _collect_password_via_dialog
 
             if not all([host, user, dbname]):
+                # `exception_class` field kept for schema consistency with the
+                # other `error: ...` responses (not_configured /
+                # write_profile_failed / keychain_write_failed). Validation
+                # has no underlying exception, so a sentinel string is used —
+                # lets agents pattern-match on a single error-response shape
+                # regardless of which failure path fired.
                 return {
                     "error": "missing_field",
+                    "exception_class": "ValidationError",
                     "message": "host, user, and dbname are all required.",
                 }
 
@@ -1377,6 +1384,17 @@ the only chat-leak-free paths.
             ok, conn_err = _test_redshift_connection(host, port, user, password, dbname)
 
             if not ok:
+                # warning (not error) — the writes succeeded, the failure is
+                # recoverable (user re-runs setup_via_dialog with corrected
+                # fields). But still worth a server-side log entry so an
+                # operator looking at server.log later can correlate
+                # client-reported "configured_but_connection_failed" responses
+                # with the underlying network / credential / cluster state.
+                logger.warning(
+                    f"setup_via_dialog: profile '{profile}' written but "
+                    f"connection test to {host}:{port}/{dbname} as {user} "
+                    f"failed: {conn_err}"
+                )
                 return {
                     "status": "configured_but_connection_failed",
                     "profile": profile,

--- a/src/redshift_comment_mcp/server.py
+++ b/src/redshift_comment_mcp/server.py
@@ -50,7 +50,8 @@ def resolve_connection_params(args: argparse.Namespace) -> tuple[str, int, str, 
         password = args.password or os.getenv('REDSHIFT_PASSWORD')
         if not password:
             raise ConfigurationError(
-                "必須透過 --password 參數或 REDSHIFT_PASSWORD 環境變數提供密碼。"
+                "Inline mode requires a password — provide --password CLI "
+                "flag or REDSHIFT_PASSWORD env var."
             )
         return args.host, args.port, args.user, password, args.dbname
 
@@ -64,39 +65,61 @@ def resolve_connection_params(args: argparse.Namespace) -> tuple[str, int, str, 
         #   switch (typo in name, or post-upgrade multi-profile with no
         #   "default" and no pointer file). List them so the user can
         #   spot the right name without re-running setup.
+        #
+        # Both messages use real "\n" between bullet items so they render
+        # as multi-line when shown to the user. Concatenated f-strings
+        # without explicit "\n" would render as a single run-on line.
         existing = cfg.list_profiles()
         if existing:
             raise ConfigurationError(
-                f"Profile '{profile_name}' is not configured. "
-                f"Existing profiles: {', '.join(existing)}. "
-                f"To switch: /redshift-comment-mcp:redshift-switch-profile (Claude Code), "
-                f"or pass `--profile <name>` to redshift-comment-mcp / set "
-                f"`REDSHIFT_COMMENT_PROFILE=<name>` env var. "
-                f"To add a new profile: /redshift-comment-mcp:redshift-setup (Claude Code), "
-                f"or `redshift-comment-mcp setup --profile <name>` (terminal), "
-                f"or code-agent pipeline `set-fields ... && set-password --dialog`."
+                f"Profile '{profile_name}' is not configured.\n"
+                f"Existing profiles: {', '.join(existing)}.\n"
+                f"To switch to an existing profile:\n"
+                f"  - Claude Code: /redshift-comment-mcp:redshift-switch-profile\n"
+                f"  - Terminal: pass `--profile <name>` to redshift-comment-mcp, "
+                f"or set `REDSHIFT_COMMENT_PROFILE=<name>` env var\n"
+                f"To add a new profile:\n"
+                f"  - Claude Code: /redshift-comment-mcp:redshift-setup\n"
+                f"  - In-band MCP tool: call `setup_via_dialog(host=..., "
+                f"user=..., dbname=...)` — password collected via OS dialog "
+                f"server-side, never crosses MCP wire / chat\n"
+                f"  - Terminal: `uvx redshift-comment-mcp setup --profile <name>`\n"
+                f"  - Code-agent Bash pipeline: `set-fields ... && set-password --dialog`"
             )
         raise ConfigurationError(
-            f"Profile '{profile_name}' is not configured. Configure via one of:"
+            f"Profile '{profile_name}' is not configured. Configure via one of:\n"
             f"  - Claude Code: /redshift-comment-mcp:redshift-setup in chat "
-            f"(password collected via system dialog, never enters chat). "
+            f"(password collected via system dialog, never enters chat).\n"
+            f"  - In-band MCP tool: call `setup_via_dialog(host=..., "
+            f"user=..., dbname=...)` — runs the same dialog mechanism inside "
+            f"this MCP session; password never crosses MCP wire / chat / "
+            f"tool args.\n"
             f"  - Code agent (any MCP client with Bash): "
             f"`redshift-comment-mcp set-fields --profile {profile_name} "
-            f"--host H --port P --user U --dbname D` "
-            f"then `redshift-comment-mcp set-password --profile {profile_name} --dialog` "
-            f"— the `--dialog` flag launches an OS-native password prompt "
-            f"(macOS osascript / Linux zenity) so the password never enters "
-            f"chat / stdout. Ask the user for host/user/dbname interactively; "
-            f"never invent them. "
-            f"  - Human in terminal: `uvx redshift-comment-mcp setup --profile {profile_name}` "
-            f"(full interactive Q&A)."
+            f"--host H --port P --user U --dbname D` then "
+            f"`redshift-comment-mcp set-password --profile {profile_name} --dialog` "
+            f"(the `--dialog` flag launches an OS-native password prompt; "
+            f"`--stdin` is the headless fallback).\n"
+            f"  - Human in terminal: `uvx redshift-comment-mcp setup "
+            f"--profile {profile_name}` (full interactive Q&A).\n"
+            f"Ask the user for host/user/dbname interactively; never invent "
+            f"them. Never pass the password as a tool argument or shell "
+            f"argument."
         )
     password = cfg.get_password(profile_name)
     if not password:
         raise ConfigurationError(
             f"Password missing from keychain for profile '{profile_name}'. "
-            f"Run /redshift-comment-mcp:redshift-setup to re-enter, or "
-            f"`redshift-comment-mcp set-password --profile {profile_name}` from a terminal."
+            f"Re-key via one of:\n"
+            f"  - Claude Code: /redshift-comment-mcp:redshift-setup\n"
+            f"  - In-band MCP tool: call `setup_via_dialog(host=..., "
+            f"user=..., dbname=...)` with the existing or new values to "
+            f"overwrite (call `get_setup_status` first if you need the "
+            f"existing field values).\n"
+            f"  - Terminal: `redshift-comment-mcp set-password --profile "
+            f"{profile_name} --dialog` (OS dialog) or `--stdin` (headless "
+            f"pipe). DO NOT use the no-flag interactive `set-password` form "
+            f"from an agent — getpass reads from /dev/tty, not stdin."
         )
     return profile["host"], profile["port"], profile["user"], password, profile["dbname"]
 

--- a/src/redshift_comment_mcp/server.py
+++ b/src/redshift_comment_mcp/server.py
@@ -2,6 +2,7 @@ import os
 import sys
 import argparse
 import logging
+from .config import ConfigurationError
 from .connection import create_redshift_config
 from .redshift_tools import RedshiftTools
 
@@ -33,18 +34,22 @@ def resolve_connection_params(args: argparse.Namespace) -> tuple[str, int, str, 
       ``~/.config/redshift-comment-mcp/config.toml``, password from OS
       keychain.
 
-    Raises ``ValueError`` with a dual-path message — pointing at both
+    Raises ``ConfigurationError`` (subclass of ``ValueError`` for backward-
+    compat) with a dual-path message — pointing at both
     ``/redshift-comment-mcp:redshift-setup`` (Claude Code skill) and
     ``redshift-comment-mcp setup`` (CLI, e.g. ``uvx redshift-comment-mcp
     setup``) — if the profile is missing or has no keychain password.
-    Surfaces a helpful next step regardless of whether the caller has
-    the Claude Code plugin installed.
+    Surfaces a helpful next step regardless of whether the caller has the
+    Claude Code plugin installed. Code paths that should react in-process
+    (e.g. degraded-mode MCP tools returning a structured not_configured
+    error) catch the specific subclass; legacy ``except ValueError`` still
+    works.
     """
     inline_complete = bool(args.host and args.user and args.dbname)
     if inline_complete:
         password = args.password or os.getenv('REDSHIFT_PASSWORD')
         if not password:
-            raise ValueError(
+            raise ConfigurationError(
                 "必須透過 --password 參數或 REDSHIFT_PASSWORD 環境變數提供密碼。"
             )
         return args.host, args.port, args.user, password, args.dbname
@@ -61,7 +66,7 @@ def resolve_connection_params(args: argparse.Namespace) -> tuple[str, int, str, 
         #   spot the right name without re-running setup.
         existing = cfg.list_profiles()
         if existing:
-            raise ValueError(
+            raise ConfigurationError(
                 f"Profile '{profile_name}' is not configured. "
                 f"Existing profiles: {', '.join(existing)}. "
                 f"To switch: /redshift-comment-mcp:redshift-switch-profile (Claude Code), "
@@ -71,7 +76,7 @@ def resolve_connection_params(args: argparse.Namespace) -> tuple[str, int, str, 
                 f"or `redshift-comment-mcp setup --profile <name>` (terminal), "
                 f"or code-agent pipeline `set-fields ... && set-password --dialog`."
             )
-        raise ValueError(
+        raise ConfigurationError(
             f"Profile '{profile_name}' is not configured. Configure via one of:"
             f"  - Claude Code: /redshift-comment-mcp:redshift-setup in chat "
             f"(password collected via system dialog, never enters chat). "
@@ -88,7 +93,7 @@ def resolve_connection_params(args: argparse.Namespace) -> tuple[str, int, str, 
         )
     password = cfg.get_password(profile_name)
     if not password:
-        raise ValueError(
+        raise ConfigurationError(
             f"Password missing from keychain for profile '{profile_name}'. "
             f"Run /redshift-comment-mcp:redshift-setup to re-enter, or "
             f"`redshift-comment-mcp set-password --profile {profile_name}` from a terminal."
@@ -134,31 +139,35 @@ def main():
     )
     parser.add_argument("--dbname", help="Redshift 資料庫名稱 (legacy inline 模式)")
     args = parser.parse_args()
-    host, port, user, password, dbname = resolve_connection_params(args)
 
-    logger.info(f"正在啟動 Redshift MCP 伺服器... (host={host}, db={dbname}, user={user})")
+    # Degraded-mode startup contract (since v0.7.0):
+    #   The server boots and enters the MCP stdio loop EVEN if no profile is
+    #   configured. Profile resolution is deferred to each MCP tool call via
+    #   the lazy provider below. A tool whose call raises ConfigurationError
+    #   returns a structured `not_configured` error to the agent instead of
+    #   crashing the server. The new `setup_via_dialog` MCP tool lets an
+    #   agent provision a profile in-band — fields via args, password via OS
+    #   dialog server-side; the password never crosses the MCP wire.
+    #
+    #   Re-resolution happens per call (no cache), so newly-written profiles
+    #   become live without restarting the MCP client.
+    def lazy_config_provider():
+        """Resolve connection params + build a RedshiftConnectionConfig.
 
-    # 1. 建立 Redshift 連線配置（不連線；per-use pattern，首次工具呼叫時才開連線）
-    try:
-        connection_config = create_redshift_config(
-            host=host,
-            port=port,
-            user=user,
-            password=password,
-            dbname=dbname,
+        Called on every MCP tool invocation that needs a DB connection.
+        Re-reads config.toml + keychain each time, so updates from
+        `setup_via_dialog` / `setup` / `set-password` take effect immediately.
+        """
+        host, port, user, password, dbname = resolve_connection_params(args)
+        return create_redshift_config(
+            host=host, port=port, user=user, password=password, dbname=dbname,
         )
-        logger.info("Redshift 連線配置建立成功")
-    except Exception as e:
-        logger.critical(f"無法建立 Redshift 連線配置：{e}")
-        return
 
-    # 2. 實例化工具提供者，傳入連線配置
-    redshift_tools = RedshiftTools(connection_config)
+    logger.info("MCP 伺服器啟動中（degraded-mode 啟動 — profile 在第一次 tool 呼叫時 lazy resolve）")
+    redshift_tools = RedshiftTools(lazy_config_provider)
     mcp_server = redshift_tools.get_server()
 
-    # 3. 啟動 MCP 伺服器
     try:
-        logger.info("MCP 伺服器啟動中...")
         mcp_server.run()  # FastMCP defaults to STDIO transport
     except KeyboardInterrupt:
         logger.info("收到中止信號，正在關閉伺服器...")

--- a/src/redshift_comment_mcp/setup_cli.py
+++ b/src/redshift_comment_mcp/setup_cli.py
@@ -102,7 +102,11 @@ def _collect_password_via_dialog(profile_name: str) -> tuple[str | None, str]:
 
     Returns ``(password, reason)``:
       - ``("the-password", "ok")`` on success
-      - ``(None, "cancelled")`` if user closed / cancelled the dialog
+      - ``(None, "cancelled")`` if user clicked Cancel on the dialog
+      - ``(None, "permission_denied")`` if macOS blocked Apple Events
+        (Claude Desktop / Cursor / etc. lacks Automation > System Events
+        permission — most common osascript failure, distinct from a user
+        cancel because the dialog never appeared)
       - ``(None, "unavailable")`` if no dialog tool is installed
       - ``(None, "unsupported")`` if the platform has no supported dialog path
 
@@ -115,8 +119,8 @@ def _collect_password_via_dialog(profile_name: str) -> tuple[str | None, str]:
     """
     if sys.platform == "darwin":
         # macOS — native osascript dialog. "with hidden answer" masks the
-        # typed value. stderr is discarded so a Cocoa permission/cancel
-        # error doesn't leak user-visible state.
+        # typed value. stderr captured (not discarded) so we can detect
+        # permission denial separately from user cancel.
         script = (
             f'tell application "System Events" to display dialog '
             f'"Redshift password for profile \\"{profile_name}\\":" '
@@ -133,9 +137,22 @@ def _collect_password_via_dialog(profile_name: str) -> tuple[str | None, str]:
             )
         except FileNotFoundError:
             return None, "unavailable"
-        if result.returncode != 0:
-            return None, "cancelled"
-        return result.stdout.rstrip("\n"), "ok"
+        if result.returncode == 0:
+            return result.stdout.rstrip("\n"), "ok"
+        # osascript non-zero exit — distinguish permission denial from cancel.
+        # macOS error -1743 ("not allowed to send Apple events") fires when
+        # the parent app (Claude Desktop / Cursor / etc.) hasn't been
+        # granted Automation > System Events permission in System Settings.
+        # The dialog never even appears; the agent should NOT treat this as
+        # "user cancelled" because that would suggest re-trying without
+        # fixing the underlying permission, leading to a hang loop.
+        stderr = (result.stderr or "")
+        if "-1743" in stderr or "not allowed to send Apple events" in stderr:
+            return None, "permission_denied"
+        # Other non-zero: most likely user clicked Cancel (also -128 /
+        # "User canceled." text in stderr, but easier to identify by
+        # exclusion of the permission case).
+        return None, "cancelled"
 
     if sys.platform.startswith("linux"):
         # Linux desktop — zenity. Exit code 1 = cancelled, 127 = not installed.
@@ -174,6 +191,18 @@ def cmd_set_password(args: argparse.Namespace) -> int:
         password, reason = _collect_password_via_dialog(name)
         if reason == "cancelled":
             print("Password dialog cancelled. No change.", file=sys.stderr)
+            return 2
+        if reason == "permission_denied":
+            print(
+                "macOS blocked the password dialog (Automation > System "
+                "Events permission denied). Fix in System Settings → "
+                "Privacy & Security → Automation → enable System Events "
+                "for the app running this command. Or run "
+                "`tccutil reset AppleEvents` from terminal to force a "
+                "fresh permission prompt. Alternatively, use `--stdin` "
+                "to pipe the password.",
+                file=sys.stderr,
+            )
             return 2
         if reason == "unavailable":
             print(

--- a/src/redshift_comment_mcp/setup_cli.py
+++ b/src/redshift_comment_mcp/setup_cli.py
@@ -120,12 +120,14 @@ def _collect_password_via_dialog(profile_name: str) -> tuple[str | None, str]:
     if sys.platform == "darwin":
         # macOS — native osascript dialog. "with hidden answer" masks the
         # typed value. stderr captured (not discarded) so we can detect
-        # permission denial separately from user cancel.
+        # permission denial separately from user cancel. Title includes
+        # the profile name so users running multiple MCP clients (Claude
+        # Desktop + Cursor + ...) can disambiguate which one popped this.
         script = (
             f'tell application "System Events" to display dialog '
             f'"Redshift password for profile \\"{profile_name}\\":" '
             f'default answer "" with hidden answer '
-            f'with title "Redshift MCP Setup" '
+            f'with title "Redshift MCP Setup — profile \\"{profile_name}\\"" '
             f'buttons {{"Cancel", "Save"}} default button "Save"'
         )
         try:
@@ -140,18 +142,28 @@ def _collect_password_via_dialog(profile_name: str) -> tuple[str | None, str]:
         if result.returncode == 0:
             return result.stdout.rstrip("\n"), "ok"
         # osascript non-zero exit — distinguish permission denial from cancel.
-        # macOS error -1743 ("not allowed to send Apple events") fires when
-        # the parent app (Claude Desktop / Cursor / etc.) hasn't been
-        # granted Automation > System Events permission in System Settings.
-        # The dialog never even appears; the agent should NOT treat this as
-        # "user cancelled" because that would suggest re-trying without
-        # fixing the underlying permission, leading to a hang loop.
-        stderr = (result.stderr or "")
-        if "-1743" in stderr or "not allowed to send Apple events" in stderr:
+        # macOS error -1743 ("Not authorized to send Apple events") fires when
+        # the parent app (Claude Desktop / Cursor / etc.) hasn't been granted
+        # Automation > System Events permission in System Settings → Privacy
+        # & Security → Automation. The dialog never even appears; the agent
+        # should NOT treat this as "user cancelled" because that would
+        # suggest a blind retry without fixing the underlying permission,
+        # producing a hang loop.
+        #
+        # Detection: prefer the numeric code (locale-stable across macOS
+        # localisations), with case-insensitive English-text fallback for
+        # both American ("authorized") and British ("authorised") spelling.
+        # Format confirmed against discussions.apple.com / Late Night
+        # Software forum threads — see PR #34's commit message for refs.
+        stderr_lower = (result.stderr or "").lower()
+        if (
+            "-1743" in (result.stderr or "")
+            or "not authorized to send apple events" in stderr_lower
+            or "not authorised to send apple events" in stderr_lower
+        ):
             return None, "permission_denied"
-        # Other non-zero: most likely user clicked Cancel (also -128 /
-        # "User canceled." text in stderr, but easier to identify by
-        # exclusion of the permission case).
+        # Other non-zero: most likely user clicked Cancel (osascript exits
+        # 1 with "execution error: User canceled. (-128)" on user cancel).
         return None, "cancelled"
 
     if sys.platform.startswith("linux"):

--- a/src/redshift_comment_mcp/setup_cli.py
+++ b/src/redshift_comment_mcp/setup_cli.py
@@ -68,6 +68,35 @@ def cmd_setup(args: argparse.Namespace) -> int:
     return cmd_test_connection(args)
 
 
+def _test_redshift_connection(
+    host: str, port: int, user: str, password: str, dbname: str,
+) -> tuple[bool, str | None]:
+    """Smoke-test a Redshift connection. Returns ``(success, error_message)``.
+
+    Catches host typos / wrong port / VPN-not-connected / firewall block /
+    wrong password / paused-cluster early. Used by both the CLI's
+    ``test-connection`` subcommand and the ``setup_via_dialog`` MCP tool
+    to verify a freshly-written profile actually connects BEFORE
+    declaring success — turns silent ``configured`` lies into actionable
+    ``configured_but_connection_failed`` feedback.
+    """
+    try:
+        import redshift_connector
+    except ImportError:
+        return False, "redshift-connector library is not installed"
+    try:
+        conn = redshift_connector.connect(
+            host=host, port=port, user=user, password=password, database=dbname,
+        )
+        try:
+            conn.cursor().execute("SELECT 1")
+        finally:
+            conn.close()
+        return True, None
+    except Exception as e:
+        return False, str(e)
+
+
 def _collect_password_via_dialog(profile_name: str) -> tuple[str | None, str]:
     """Collect password via OS-native dialog without exposing to chat / stdout.
 

--- a/tests/e2e/test_setup_via_dialog_wire.py
+++ b/tests/e2e/test_setup_via_dialog_wire.py
@@ -1,0 +1,93 @@
+"""E2E wire-level checks for setup_via_dialog MCP tool (v0.7.0).
+
+What's exercised here that in-process tests cannot reach:
+
+  - tools/list registers `setup_via_dialog` after FastMCP serialization
+    (catches accidental un-registration during refactor)
+  - The SETUP RECOVERY block in server `instructions` reaches the client
+    intact through the MCP capability handshake
+
+Does NOT exercise the tool's runtime side effects (would touch real OS
+keychain / spawn osascript dialog). Functional behavior is covered by the
+unit tests in tests/test_tools.py with mocks; this file's responsibility
+stops at the wire boundary.
+
+Lighter opt-in than the other e2e file: these tests don't require a
+configured profile (degraded-mode startup is what they verify), but
+they still spawn a subprocess so we gate on REDSHIFT_INTEGRATION=1 for
+CI cost control. Single env-var flip enables both wire tiers.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+import pytest
+from fastmcp import Client
+from fastmcp.client.transports import StdioTransport
+
+SETUP_RECOVERY_MARKER = "SETUP RECOVERY"
+OPT_IN_ENV = "REDSHIFT_INTEGRATION"
+
+
+@pytest.fixture(scope="module")
+def e2e_wire_opt_in():
+    """Lighter gate than tests/e2e/conftest.py:e2e_preconditions_satisfied —
+    only checks the opt-in env var, not profile state. v0.7.0 servers boot
+    without a profile, so these wire-level tests don't need one configured."""
+    if os.environ.get(OPT_IN_ENV) != "1":
+        pytest.skip(
+            f"Wire-level e2e tests require {OPT_IN_ENV}=1 to opt in. "
+            f"Run with `{OPT_IN_ENV}=1 uv run pytest tests/e2e/`."
+        )
+
+
+def _spawn_transport() -> StdioTransport:
+    """Spawn the server as a Python subprocess via the same import path the
+    pyproject.toml console-script entry uses."""
+    return StdioTransport(
+        command=sys.executable,
+        args=["-c", "from redshift_comment_mcp.server import main; main()"],
+    )
+
+
+async def _run_tools_list_registers_setup_via_dialog():
+    """setup_via_dialog must appear in tools/list. Defends against
+    accidental un-registration during refactor + verifies FastMCP's
+    introspection sees a tool decorated WITHOUT @_guarded correctly
+    (since setup_via_dialog deliberately skips that decorator)."""
+    async with Client(_spawn_transport()) as client:
+        tools = await client.list_tools()
+        names = {t.name for t in tools}
+        assert "setup_via_dialog" in names, (
+            f"setup_via_dialog missing from tools/list "
+            f"(got {len(names)} tools total)"
+        )
+
+
+async def _run_instructions_handshake_carries_setup_recovery_block():
+    """The SETUP RECOVERY block in `instructions=` reaches the MCP client
+    via the capability handshake. This is how agents discover the
+    degraded-mode flow BEFORE encountering a not_configured error — without
+    it, agents must hit the error first then read the next_step field. The
+    handshake-time channel is the cleaner UX."""
+    async with Client(_spawn_transport()) as client:
+        init = client.initialize_result
+        instructions = (init.instructions or "") if init else ""
+        # Cite the marker, not the full block — keeps failure dump clean.
+        assert SETUP_RECOVERY_MARKER in instructions, (
+            f"server instructions missing {SETUP_RECOVERY_MARKER!r} "
+            f"(length={len(instructions)})"
+        )
+
+
+# ===== sync pytest entry points =====
+
+
+def test_tools_list_registers_setup_via_dialog_via_wire(e2e_wire_opt_in):
+    asyncio.run(_run_tools_list_registers_setup_via_dialog())
+
+
+def test_instructions_handshake_carries_setup_recovery_block(e2e_wire_opt_in):
+    asyncio.run(_run_instructions_handshake_carries_setup_recovery_block())

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -62,7 +62,7 @@ def live_redshift_tools():
         password=password,
         dbname=profile["dbname"],
     )
-    return RedshiftTools(config)
+    return RedshiftTools(lambda: config)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_server_resolution.py
+++ b/tests/test_server_resolution.py
@@ -164,10 +164,12 @@ def test_profile_mode_cli_flag_beats_env_and_file(tmp_xdg, fake_keyring, monkeyp
 # ===== profile mode error messages point at both skill and CLI =====
 
 
-def test_profile_not_configured_error_offers_three_paths(tmp_xdg, fake_keyring, monkeypatch):
-    """Error must surface all three setup paths so any caller can recover:
-    Claude Code skill, code-agent pipeline (set-fields + set-password
-    --dialog), and human terminal (uvx redshift-comment-mcp setup)."""
+def test_profile_not_configured_error_offers_recovery_paths(tmp_xdg, fake_keyring, monkeypatch):
+    """Error must surface all setup paths so any caller can recover:
+    Claude Code skill, in-band MCP tool setup_via_dialog, code-agent
+    pipeline (set-fields + set-password --dialog), and human terminal
+    (uvx redshift-comment-mcp setup). Name kept path-agnostic so adding
+    a 5th option later doesn't require a test rename."""
     monkeypatch.delenv("REDSHIFT_COMMENT_PROFILE", raising=False)
     args = _ns()
     with pytest.raises(ValueError) as excinfo:
@@ -196,9 +198,11 @@ def test_named_profile_not_configured_error_includes_name(tmp_xdg, fake_keyring,
     assert "ichef-prod" in str(excinfo.value)
 
 
-def test_profile_exists_but_no_password_error_offers_two_paths(tmp_xdg, fake_keyring, monkeypatch):
+def test_profile_exists_but_no_password_error_offers_recovery_paths(tmp_xdg, fake_keyring, monkeypatch):
     """If profile fields exist but password missing, error should offer
-    BOTH the skill (preferred) AND the set-password CLI fallback."""
+    multiple re-key paths (Claude Code skill, in-band setup_via_dialog,
+    and terminal set-password CLI). Name kept path-agnostic so adding
+    new options later doesn't require a test rename."""
     monkeypatch.delenv("REDSHIFT_COMMENT_PROFILE", raising=False)
     config.write_profile("default", host="h", port=5439, user="u", dbname="d")
     # No password set → keychain miss

--- a/tests/test_setup_cli.py
+++ b/tests/test_setup_cli.py
@@ -308,14 +308,15 @@ def test_set_password_stdin_empty_returns_2(tmp_xdg, fake_keyring, monkeypatch, 
 # ===== set-password --dialog =====
 
 
-def _mock_subprocess_run(returncode: int, stdout: str = "", raise_=None):
+def _mock_subprocess_run(returncode: int, stdout: str = "", stderr: str = "", raise_=None):
     """Build a subprocess.run replacement that returns a fake CompletedProcess
     (or raises) so dialog paths can be exercised without launching osascript /
-    zenity in tests."""
+    zenity in tests. ``stderr`` is needed to drive macOS permission-denied
+    detection (which reads osascript's stderr for the -1743 code)."""
     def _run(*_args, **_kwargs):
         if raise_ is not None:
             raise raise_
-        return types.SimpleNamespace(returncode=returncode, stdout=stdout, stderr="")
+        return types.SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
     return _run
 
 
@@ -409,3 +410,85 @@ def test_set_password_stdin_and_dialog_are_mutually_exclusive(
         setup_cli.main(["set-password", "--profile", "default", "--stdin", "--dialog"])
     assert excinfo.value.code == 2
     assert "not allowed with argument" in capsys.readouterr().err
+
+
+# ===== macOS Apple-Events permission denial detection =====
+#
+# osascript returns exit code != 0 for both user-cancel AND
+# Automation-permission-denied (-1743). Pre-v0.7.0-polish these were
+# conflated as "cancelled". The helper now reads stderr to distinguish them
+# so the agent can give the user actionable advice (System Settings →
+# Privacy & Security → Automation) instead of just "you cancelled".
+
+
+@pytest.mark.parametrize("stderr_text", [
+    "execution error: System Events got an error: ... (-1743)",
+    "Not authorized to send Apple events to System Events. (-1743)",
+    "execution error: redshift-comment-mcp is not allowed to send Apple events.",
+])
+def test_collect_password_via_dialog_detects_permission_denied(stderr_text, monkeypatch):
+    """The helper must classify osascript's -1743 / 'not allowed to send
+    Apple events' stderr as `permission_denied`, NOT `cancelled`. Both
+    numeric code and English text variants exist depending on macOS
+    version; parametrize over the realistic stderr shapes."""
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setattr(
+        "redshift_comment_mcp.setup_cli.subprocess.run",
+        _mock_subprocess_run(returncode=1, stdout="", stderr=stderr_text),
+    )
+
+    pw, reason = setup_cli._collect_password_via_dialog("default")
+
+    assert pw is None
+    assert reason == "permission_denied", (
+        f"stderr={stderr_text!r} should have been classified as "
+        f"permission_denied (got {reason!r})"
+    )
+
+
+def test_collect_password_via_dialog_distinguishes_cancel_from_permission(monkeypatch):
+    """Plain user-cancel still returns `cancelled` — the stderr lacks the
+    -1743 / Apple-events tell so the permission heuristic doesn't fire."""
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setattr(
+        "redshift_comment_mcp.setup_cli.subprocess.run",
+        _mock_subprocess_run(
+            returncode=1, stdout="",
+            stderr="execution error: User canceled. (-128)",
+        ),
+    )
+
+    pw, reason = setup_cli._collect_password_via_dialog("default")
+
+    assert pw is None
+    assert reason == "cancelled"
+
+
+def test_set_password_dialog_permission_denied_returns_2_with_tcc_hint(
+    tmp_xdg, fake_keyring, monkeypatch, capsys
+):
+    """CLI level: `set-password --dialog` surfaces the permission_denied
+    case with an actionable hint (System Settings + tccutil reset) so a
+    terminal user can fix the underlying permission without guessing."""
+    config.write_profile("default", host="h", port=5439, user="u", dbname="d")
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setattr(
+        "redshift_comment_mcp.setup_cli.subprocess.run",
+        _mock_subprocess_run(
+            returncode=1, stdout="",
+            stderr="execution error: ... (-1743)",
+        ),
+    )
+
+    rc = setup_cli.main(["set-password", "--profile", "default", "--dialog"])
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "blocked" in err.lower() or "permission" in err.lower(), (
+        f"err should call out the permission block; got: {err!r}"
+    )
+    # Concrete next-step hints
+    assert "System Settings" in err or "Privacy" in err
+    assert "tccutil reset AppleEvents" in err or "Automation" in err
+    # Don't conflate with cancellation
+    assert "cancelled" not in err.lower()

--- a/tests/test_setup_cli.py
+++ b/tests/test_setup_cli.py
@@ -422,15 +422,29 @@ def test_set_password_stdin_and_dialog_are_mutually_exclusive(
 
 
 @pytest.mark.parametrize("stderr_text", [
-    "execution error: System Events got an error: ... (-1743)",
-    "Not authorized to send Apple events to System Events. (-1743)",
-    "execution error: redshift-comment-mcp is not allowed to send Apple events.",
+    # Canonical format from Apple's osascript on macOS 10.14+; both
+    # numeric code AND English text confirmed via Apple Community thread
+    # and Late Night Software forum.
+    "execution error: Not authorized to send Apple events to System Events. (-1743)",
+    # British spelling variant — same numeric code, different word
+    "execution error: Not authorised to send Apple events to System Events. (-1743)",
+    # Older / locale variant: numeric code without the standard English
+    # prose (some non-en locales may emit translated text + the number)
+    "実行エラー: System Events ... (-1743)",
+    # Edge: just the numeric code in some context
+    "Some prefix (-1743) suffix",
+    # Edge: case variation — lowercase "not authorized"
+    "execution error: not authorized to send apple events.",
 ])
 def test_collect_password_via_dialog_detects_permission_denied(stderr_text, monkeypatch):
-    """The helper must classify osascript's -1743 / 'not allowed to send
-    Apple events' stderr as `permission_denied`, NOT `cancelled`. Both
-    numeric code and English text variants exist depending on macOS
-    version; parametrize over the realistic stderr shapes."""
+    """The helper must classify osascript's -1743 stderr as
+    `permission_denied`, NOT `cancelled`. Detection covers (a) the numeric
+    code (locale-stable across all macOS localisations) and (b) the
+    English text in both American and British spellings, case-insensitive.
+
+    Test cases derived from real-world osascript output documented in the
+    macOS Apple Events ecosystem (Apple Community / Late Night Software
+    forum) — see PR #34 commit message for source URLs."""
     monkeypatch.setattr("sys.platform", "darwin")
     monkeypatch.setattr(
         "redshift_comment_mcp.setup_cli.subprocess.run",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1532,6 +1532,12 @@ class TestSetupViaDialogTool:
             'redshift_comment_mcp.setup_cli._collect_password_via_dialog',
             lambda profile: ("dialog-secret", "ok"),
         )
+        # Stub the post-write connection test to simulate a reachable cluster
+        # — keeps this test hermetic (no real Redshift attempt).
+        monkeypatch.setattr(
+            'redshift_comment_mcp.setup_cli._test_redshift_connection',
+            lambda *args, **kw: (True, None),
+        )
 
         tools = self._make_tools()  # provider raises ConfigurationError
         setup_via_dialog = _get_tool_fn(tools, 'setup_via_dialog')
@@ -1732,6 +1738,10 @@ class TestSetupViaDialogTool:
             'redshift_comment_mcp.setup_cli._collect_password_via_dialog',
             lambda profile: ("pw", "ok"),
         )
+        monkeypatch.setattr(
+            'redshift_comment_mcp.setup_cli._test_redshift_connection',
+            lambda *args, **kw: (True, None),
+        )
 
         tools = self._make_tools()
         setup_via_dialog = _get_tool_fn(tools, 'setup_via_dialog')
@@ -1798,6 +1808,12 @@ class TestDegradedModeContractAdditional:
         monkeypatch.setattr(
             'redshift_comment_mcp.setup_cli._collect_password_via_dialog',
             lambda profile: ("dialog-pw", "ok"),
+        )
+        # End-to-end test stubs the connection check too — covered by
+        # dedicated TestSetupViaDialogConnectionVerification tests below.
+        monkeypatch.setattr(
+            'redshift_comment_mcp.setup_cli._test_redshift_connection',
+            lambda *args, **kw: (True, None),
         )
 
         tools = RedshiftTools(lazy_provider)
@@ -1905,3 +1921,237 @@ class TestServerStartup:
             f"(expected exactly 1 — server should reach the stdio loop even "
             f"without a configured profile)"
         )
+
+
+# ===== Polish round-3: connection verification + get_setup_status =====
+#
+# These tests cover the additional safety net (test connection after
+# keychain write) and the new read-only status tool.
+
+
+class TestSetupViaDialogConnectionVerification:
+    """setup_via_dialog now tests the Redshift connection after writing the
+    profile + password. This catches "wrote successfully but connection
+    fails" silent lies (typo'd host / VPN not connected / wrong password /
+    paused cluster) BEFORE the agent declares setup done."""
+
+    def _make_tools(self):
+        from redshift_comment_mcp.config import ConfigurationError
+        def provider():
+            raise ConfigurationError("not yet")
+        return RedshiftTools(provider)
+
+    def _setup_common_mocks(self, monkeypatch, dialog_returns=("pw", "ok")):
+        """Stub the chain up to the connection-test step."""
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.write_profile',
+            lambda name, **kw: None,
+        )
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.set_password',
+            lambda name, pw: None,
+        )
+        monkeypatch.setattr(
+            'redshift_comment_mcp.setup_cli._collect_password_via_dialog',
+            lambda profile: dialog_returns,
+        )
+
+    def test_connection_test_passes_returns_configured_with_tested_flag(self, monkeypatch):
+        self._setup_common_mocks(monkeypatch)
+        monkeypatch.setattr(
+            'redshift_comment_mcp.setup_cli._test_redshift_connection',
+            lambda *args, **kw: (True, None),
+        )
+
+        tools = self._make_tools()
+        setup_via_dialog = _get_tool_fn(tools, 'setup_via_dialog')
+
+        result = setup_via_dialog(host='h', user='u', dbname='d')
+
+        assert result["status"] == "configured"
+        assert result["tested"] is True
+        assert "succeeded" in result["message"].lower()
+
+    def test_connection_test_fails_returns_configured_but_connection_failed(self, monkeypatch):
+        """The keystone safety: profile fields and password were saved, but
+        the connection test caught a mismatch. Agent should NOT declare
+        setup done; should re-prompt user."""
+        self._setup_common_mocks(monkeypatch)
+        monkeypatch.setattr(
+            'redshift_comment_mcp.setup_cli._test_redshift_connection',
+            lambda *args, **kw: (False, "Connection timed out (host unreachable)"),
+        )
+
+        tools = self._make_tools()
+        setup_via_dialog = _get_tool_fn(tools, 'setup_via_dialog')
+
+        result = setup_via_dialog(host='wrong.example.com', user='u', dbname='d')
+
+        assert result["status"] == "configured_but_connection_failed"
+        assert result["tested"] is False
+        assert "timed out" in result["connection_error"]
+        # Message must include diagnostic hints the agent can relay to user
+        assert "VPN" in result["message"] or "host" in result["message"].lower()
+        # Profile name preserved so agent knows which one to re-setup
+        assert result["profile"] == "default"
+
+    def test_connection_test_args_include_resolved_values(self, monkeypatch):
+        """Verify _test_redshift_connection is called with the actual
+        host/port/user/password/dbname the tool received — guards against
+        accidentally passing wrong args (e.g. dropping port, swapping
+        user/dbname order)."""
+        self._setup_common_mocks(monkeypatch, dialog_returns=("the-password", "ok"))
+        captured = {}
+        def capture(host, port, user, password, dbname):
+            captured.update(host=host, port=port, user=user,
+                            password=password, dbname=dbname)
+            return (True, None)
+        monkeypatch.setattr(
+            'redshift_comment_mcp.setup_cli._test_redshift_connection', capture,
+        )
+
+        tools = self._make_tools()
+        setup_via_dialog = _get_tool_fn(tools, 'setup_via_dialog')
+        setup_via_dialog(host='h.example.com', user='alice',
+                         dbname='analytics', port=5430)
+
+        assert captured == {
+            'host': 'h.example.com',
+            'port': 5430,
+            'user': 'alice',
+            'password': 'the-password',
+            'dbname': 'analytics',
+        }
+
+
+class TestGetSetupStatusTool:
+    """The read-only setup-status tool. Safe to call at session start;
+    returns non-secrets only; agents use it to decide whether to call
+    setup_via_dialog proactively."""
+
+    def _make_tools(self):
+        from redshift_comment_mcp.config import ConfigurationError
+        def provider():
+            raise ConfigurationError("doesn't matter — get_setup_status doesn't touch the provider")
+        return RedshiftTools(provider)
+
+    def test_get_setup_status_unconfigured_returns_false_with_next_step(self, monkeypatch):
+        """Fresh install case: no config.toml entry, no keychain."""
+        monkeypatch.setattr('redshift_comment_mcp.config.read_profile',
+                            lambda name: None)
+        monkeypatch.setattr('redshift_comment_mcp.config.get_password',
+                            lambda name: None)
+
+        tools = self._make_tools()
+        get_setup_status = _get_tool_fn(tools, 'get_setup_status')
+
+        result = get_setup_status()
+
+        assert result["profile"] == "default"
+        assert result["configured"] is False
+        assert result["has_fields"] is False
+        assert result["has_password"] is False
+        # Non-secret fields absent when has_fields=False
+        assert "host" not in result
+        assert "user" not in result
+        # Agent guidance for next step
+        assert "next_step" in result
+        assert "setup_via_dialog" in result["next_step"]
+
+    def test_get_setup_status_fields_only_no_password(self, monkeypatch):
+        """Edge case: config.toml has the profile but keychain entry was
+        deleted (e.g. via `delete-profile` then re-add of fields only)."""
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.read_profile',
+            lambda name: {'host': 'h', 'port': 5439, 'user': 'u', 'dbname': 'd'},
+        )
+        monkeypatch.setattr('redshift_comment_mcp.config.get_password',
+                            lambda name: None)
+
+        tools = self._make_tools()
+        get_setup_status = _get_tool_fn(tools, 'get_setup_status')
+
+        result = get_setup_status()
+
+        assert result["configured"] is False  # NOT fully configured
+        assert result["has_fields"] is True
+        assert result["has_password"] is False
+        # Non-secret fields exposed
+        assert result["host"] == 'h'
+        assert result["user"] == 'u'
+        # next_step adapts to this partial state
+        assert "password" in result["next_step"].lower()
+
+    def test_get_setup_status_fully_configured(self, monkeypatch):
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.read_profile',
+            lambda name: {'host': 'h.example.com', 'port': 5439,
+                          'user': 'alice', 'dbname': 'analytics'},
+        )
+        monkeypatch.setattr('redshift_comment_mcp.config.get_password',
+                            lambda name: 'some-password')
+
+        tools = self._make_tools()
+        get_setup_status = _get_tool_fn(tools, 'get_setup_status')
+
+        result = get_setup_status(profile='default')
+
+        assert result["configured"] is True
+        assert result["has_fields"] is True
+        assert result["has_password"] is True
+        assert result["host"] == 'h.example.com'
+        assert result["user"] == 'alice'
+        # No next_step when already configured
+        assert "next_step" not in result
+
+    def test_get_setup_status_never_returns_password_value(self, monkeypatch):
+        """Hard security invariant: even when has_password=True, the actual
+        password string MUST NEVER appear anywhere in the response. Catches
+        a future careless refactor where someone adds the password to the
+        response by accident."""
+        secret = "super-secret-password-do-not-leak"
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.read_profile',
+            lambda name: {'host': 'h', 'port': 5439, 'user': 'u', 'dbname': 'd'},
+        )
+        monkeypatch.setattr('redshift_comment_mcp.config.get_password',
+                            lambda name: secret)
+
+        tools = self._make_tools()
+        get_setup_status = _get_tool_fn(tools, 'get_setup_status')
+
+        result = get_setup_status()
+
+        # Scan all string values in the response for the secret — catches
+        # accidental inclusion in any field (host, message, next_step, etc).
+        import json
+        serialized = json.dumps(result)
+        assert secret not in serialized, (
+            "get_setup_status leaked the password value in the response — "
+            "this is a security regression"
+        )
+
+    def test_get_setup_status_works_in_degraded_mode(self, monkeypatch):
+        """get_setup_status must work even when the lazy provider raises
+        ConfigurationError — that's literally what makes it useful at
+        session start (no profile yet)."""
+        from redshift_comment_mcp.config import ConfigurationError
+
+        def failing_provider():
+            raise ConfigurationError("not yet configured")
+
+        monkeypatch.setattr('redshift_comment_mcp.config.read_profile',
+                            lambda name: None)
+        monkeypatch.setattr('redshift_comment_mcp.config.get_password',
+                            lambda name: None)
+
+        tools = RedshiftTools(failing_provider)
+        get_setup_status = _get_tool_fn(tools, 'get_setup_status')
+
+        # Must NOT raise; must NOT return not_configured error
+        result = get_setup_status()
+        assert "error" not in result, (
+            "get_setup_status should not be guarded by @_guarded — it "
+            "needs to work when the provider raises (its whole point)"
+        )
+        assert result["configured"] is False

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1612,3 +1612,296 @@ class TestSetupViaDialogTool:
 
         assert result["error"] == "missing_field"
         assert len(write_calls) == 0  # nothing was written
+
+    # ===== additional coverage rounds (gap-fill) =====
+
+    def test_setup_via_dialog_platform_unsupported_returns_status(self, monkeypatch):
+        """Platforms without osascript/zenity wiring (e.g. Windows) get the
+        unsupported branch. Profile fields are still saved so the user can
+        re-key with --stdin later."""
+        write_calls = []
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.write_profile',
+            lambda name, **kw: write_calls.append((name, kw)),
+        )
+        monkeypatch.setattr(
+            'redshift_comment_mcp.setup_cli._collect_password_via_dialog',
+            lambda profile: (None, "unsupported"),
+        )
+
+        tools = self._make_tools()
+        setup_via_dialog = _get_tool_fn(tools, 'setup_via_dialog')
+
+        result = setup_via_dialog(host='h', user='u', dbname='d')
+
+        assert result["status"] == "platform_unsupported"
+        assert "platform" in result  # carries the platform name for debugging
+        assert "--stdin" in result["message"]
+        assert len(write_calls) == 1  # fields were saved even though password wasn't
+
+    def test_setup_via_dialog_empty_password_status(self, monkeypatch):
+        """Dialog returned (\"\", \"ok\") — weird state where the user clicked
+        OK without typing anything. Treat as failure; don't write an empty
+        password to keychain."""
+        set_pw_calls = []
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.write_profile',
+            lambda name, **kw: None,
+        )
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.set_password',
+            lambda name, pw: set_pw_calls.append((name, pw)),
+        )
+        monkeypatch.setattr(
+            'redshift_comment_mcp.setup_cli._collect_password_via_dialog',
+            lambda profile: ("", "ok"),  # dialog OK but empty
+        )
+
+        tools = self._make_tools()
+        setup_via_dialog = _get_tool_fn(tools, 'setup_via_dialog')
+
+        result = setup_via_dialog(host='h', user='u', dbname='d')
+
+        assert result["status"] == "empty_password"
+        assert len(set_pw_calls) == 0  # password was NOT written to keychain
+
+    def test_setup_via_dialog_write_profile_failed_returns_error(self, monkeypatch):
+        """write_profile raises (e.g. config dir not writable) → tool exits
+        with a clear error BEFORE touching the dialog. Defensive: catches
+        disk-permission issues without prompting the user for password
+        for nothing."""
+        def failing_write(name, **kw):
+            raise PermissionError("config dir not writable")
+        monkeypatch.setattr('redshift_comment_mcp.config.write_profile', failing_write)
+        # Dialog should not even be called — assert via tripwire:
+        dialog_calls = []
+        monkeypatch.setattr(
+            'redshift_comment_mcp.setup_cli._collect_password_via_dialog',
+            lambda profile: dialog_calls.append(profile) or ("x", "ok"),
+        )
+
+        tools = self._make_tools()
+        setup_via_dialog = _get_tool_fn(tools, 'setup_via_dialog')
+
+        result = setup_via_dialog(host='h', user='u', dbname='d')
+
+        assert result["error"] == "write_profile_failed"
+        assert "not writable" in result["message"]
+        assert dialog_calls == []  # tripwire: dialog was NOT invoked
+
+    def test_setup_via_dialog_keychain_write_failed_returns_error(self, monkeypatch):
+        """set_password raises (e.g. keychain locked / access denied) AFTER
+        write_profile succeeded → tool returns keychain_write_failed. The
+        config.toml entry is left behind (recoverable: user can re-key via
+        set-password --dialog later)."""
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.write_profile',
+            lambda name, **kw: None,
+        )
+        def failing_set(name, pw):
+            raise RuntimeError("keychain locked")
+        monkeypatch.setattr('redshift_comment_mcp.config.set_password', failing_set)
+        monkeypatch.setattr(
+            'redshift_comment_mcp.setup_cli._collect_password_via_dialog',
+            lambda profile: ("dialog-pw", "ok"),
+        )
+
+        tools = self._make_tools()
+        setup_via_dialog = _get_tool_fn(tools, 'setup_via_dialog')
+
+        result = setup_via_dialog(host='h', user='u', dbname='d')
+
+        assert result["error"] == "keychain_write_failed"
+        assert "locked" in result["message"]
+
+    def test_setup_via_dialog_overwrites_existing_profile(self, monkeypatch):
+        """Calling setup_via_dialog with an existing profile name should
+        overwrite the fields (same UX as /redshift-setup skill). Second call
+        wins — final state is the most recent invocation's args."""
+        write_calls = []
+        pw_calls = []
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.write_profile',
+            lambda name, **kw: write_calls.append((name, kw)),
+        )
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.set_password',
+            lambda name, pw: pw_calls.append((name, pw)),
+        )
+        monkeypatch.setattr(
+            'redshift_comment_mcp.setup_cli._collect_password_via_dialog',
+            lambda profile: ("pw", "ok"),
+        )
+
+        tools = self._make_tools()
+        setup_via_dialog = _get_tool_fn(tools, 'setup_via_dialog')
+
+        r1 = setup_via_dialog(host='old-host', user='u1', dbname='d1', profile='default')
+        r2 = setup_via_dialog(host='new-host', user='u2', dbname='d2', profile='default')
+
+        assert r1["status"] == "configured" and r2["status"] == "configured"
+        assert len(write_calls) == 2
+        assert write_calls[0][1]['host'] == 'old-host'
+        assert write_calls[1][1]['host'] == 'new-host'  # second call overwrites
+        assert len(pw_calls) == 2
+
+    def test_fastmcp_instructions_contains_setup_recovery_block(self):
+        """The SETUP RECOVERY block in FastMCP `instructions=` is the agent's
+        discovery channel for degraded-mode UX at handshake time. Regression
+        net against accidental removal during instructions edit / refactor."""
+        tools = self._make_tools()
+        instructions = tools.mcp.instructions or ""
+        assert "SETUP RECOVERY" in instructions, (
+            "instructions= missing SETUP RECOVERY block — agents lose the "
+            "handshake-time discovery channel for degraded-mode UX"
+        )
+        assert "setup_via_dialog" in instructions, (
+            "instructions= must name setup_via_dialog so agents know which "
+            "tool to call on not_configured error"
+        )
+        assert "not_configured" in instructions, (
+            "instructions= must name the not_configured error code so the "
+            "agent can pattern-match it"
+        )
+
+
+class TestDegradedModeContractAdditional:
+    """Round-2 coverage: end-to-end bootstrap-then-use, lazy-property direct
+    verification, and guard scope (only ConfigurationError gets converted —
+    other exceptions propagate normally)."""
+
+    def test_bootstrap_then_use_end_to_end(self, monkeypatch, mock_config):
+        """The v0.7.0 promise visualised: server boots without profile, agent
+        sets it up via the MCP tool, next DB tool call works WITHOUT a
+        restart. Glues all three changes together (degraded-mode start, lazy
+        re-resolution, setup_via_dialog write) and proves they compose."""
+        from redshift_comment_mcp.config import ConfigurationError
+
+        config, mock_conn = mock_config
+        # Shared state simulating "is the profile configured yet" — flipped
+        # by the mocked set_password (last step of setup_via_dialog).
+        state = {"configured": False}
+
+        def lazy_provider():
+            if state["configured"]:
+                return config
+            raise ConfigurationError("Profile 'default' is not configured")
+
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.write_profile',
+            lambda name, **kw: None,
+        )
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.set_password',
+            lambda name, pw: state.__setitem__("configured", True),
+        )
+        monkeypatch.setattr(
+            'redshift_comment_mcp.setup_cli._collect_password_via_dialog',
+            lambda profile: ("dialog-pw", "ok"),
+        )
+
+        tools = RedshiftTools(lazy_provider)
+        list_schemas = _get_tool_fn(tools, 'list_schemas')
+        setup_via_dialog = _get_tool_fn(tools, 'setup_via_dialog')
+
+        # 1. Initial call: not configured — server didn't crash, tool returned error
+        first = list_schemas()
+        assert first.get("error") == "not_configured", (
+            f"Step 1: expected not_configured error, got {first}"
+        )
+
+        # 2. Agent calls setup_via_dialog with conversational fields
+        setup = setup_via_dialog(host='h.example.com', user='u', dbname='d')
+        assert setup["status"] == "configured", f"Step 2: setup failed: {setup}"
+
+        # 3. Same tool call now works — NO restart, lazy resolve picked up state
+        with patch('awswrangler.redshift.read_sql_query') as mock_read:
+            mock_read.return_value = pd.DataFrame({
+                'schema_name': ['public'],
+                'schema_comment': ['ok'],
+            })
+            success = list_schemas()
+        assert success.get("error") != "not_configured", (
+            f"Step 3: lazy resolve should have picked up new profile, got {success}"
+        )
+        assert "schemas" in success or "items" in success, (
+            f"Step 3: expected schemas in response, got keys: {list(success.keys())}"
+        )
+
+    def test_config_property_is_lazy_not_cached(self):
+        """Each access to `tools.config` invokes the provider afresh — no
+        process-internal cache. This is what makes lazy re-resolution
+        actually pick up new keychain writes (no cache to invalidate)."""
+        call_count = [0]
+        sentinel = object()
+
+        def provider():
+            call_count[0] += 1
+            return sentinel
+
+        tools = RedshiftTools(provider)
+
+        assert tools.config is sentinel
+        assert tools.config is sentinel
+        assert tools.config is sentinel
+        assert call_count[0] == 3, (
+            f"@property config should call provider on every access "
+            f"(got {call_count[0]} calls for 3 accesses — caching has crept in)"
+        )
+
+    def test_guarded_does_not_catch_non_configuration_errors(self, mock_config):
+        """@_guarded converts ConfigurationError to not_configured response.
+        Other exceptions (validation, DB errors, etc.) MUST propagate
+        unchanged so FastMCP can surface them through normal error handling.
+        Catches the bug where someone widens the except clause to bare
+        Exception, hiding real failures behind a misleading not_configured
+        response."""
+        config, mock_conn = mock_config
+        tools = RedshiftTools(lambda: config)
+
+        execute_sql = _get_tool_fn(tools, 'execute_sql')
+
+        # validate_read_only_sql raises plain ValueError (not ConfigurationError)
+        # → must propagate, NOT get caught by @_guarded
+        with pytest.raises(ValueError, match="SELECT and WITH"):
+            execute_sql(sql_statement="DROP TABLE users")
+
+
+class TestServerStartup:
+    """v0.7.0 degraded-mode contract at the server entry point: server.main()
+    must NOT raise when no profile is configured."""
+
+    def test_server_main_does_not_crash_when_no_profile(self, monkeypatch, tmp_path):
+        """The keystone test: invoke server.main() with an empty XDG config
+        dir + stubbed mcp_server.run(). Pre-v0.7.0 this raised
+        ValueError("Profile 'default' is not configured...") and exited with
+        traceback. Post-v0.7.0 it must enter the stdio loop. A failure here
+        means someone re-introduced upfront resolve_connection_params() in
+        main()."""
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))  # empty config dir
+        monkeypatch.delenv("REDSHIFT_COMMENT_PROFILE", raising=False)
+        monkeypatch.setattr("sys.argv", ["redshift-comment-mcp"])
+
+        # Stub mcp_server.run() so this test doesn't enter the actual stdio
+        # blocking loop. FastMCP's .run method is replaced at class level →
+        # any instance the server creates uses the stub.
+        run_invocations = []
+        from fastmcp import FastMCP
+        monkeypatch.setattr(
+            FastMCP,
+            "run",
+            lambda self, *args, **kwargs: run_invocations.append(self),
+        )
+
+        from redshift_comment_mcp import server as server_module
+
+        # The assertion is the call itself — it must NOT raise.
+        server_module.main()
+
+        # And mcp_server.run() should have been entered exactly once, proving
+        # the server reached the stdio-loop step instead of bailing early.
+        assert len(run_invocations) == 1, (
+            f"mcp_server.run() invoked {len(run_invocations)} times "
+            f"(expected exactly 1 — server should reach the stdio loop even "
+            f"without a configured profile)"
+        )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1718,9 +1718,16 @@ class TestSetupViaDialogTool:
         """write_profile raises (e.g. config dir not writable) → tool exits
         with a clear error BEFORE touching the dialog. Defensive: catches
         disk-permission issues without prompting the user for password
-        for nothing."""
+        for nothing.
+
+        Per CWE-209 (round-5 polish): the raw str(e) MUST NOT appear in
+        the response message — the exception class name IS exposed (as
+        a separate field, useful for diagnosis), but the message text
+        is sanitized."""
+        secret_marker = "SUPER_SENSITIVE_PATH_/Users/private/.aws/credentials"
         def failing_write(name, **kw):
-            raise PermissionError("config dir not writable")
+            # Simulate an exception whose str() contains sensitive context
+            raise PermissionError(secret_marker)
         monkeypatch.setattr('redshift_comment_mcp.config.write_profile', failing_write)
         # Dialog should not even be called — assert via tripwire:
         dialog_calls = []
@@ -1735,20 +1742,36 @@ class TestSetupViaDialogTool:
         result = setup_via_dialog(host='h', user='u', dbname='d')
 
         assert result["error"] == "write_profile_failed"
-        assert "not writable" in result["message"]
+        assert result["exception_class"] == "PermissionError"
+        # CWE-209: response MUST NOT carry raw exception text
+        import json
+        serialized = json.dumps(result)
+        assert secret_marker not in serialized, (
+            "write_profile_failed response leaked raw exception text — "
+            "CWE-209 regression"
+        )
+        # ...but should still be agent-actionable
+        assert "config" in result["message"].lower() or "filesystem" in result["message"].lower()
         assert dialog_calls == []  # tripwire: dialog was NOT invoked
 
     def test_setup_via_dialog_keychain_write_failed_returns_error(self, monkeypatch):
         """set_password raises (e.g. keychain locked / access denied) AFTER
         write_profile succeeded → tool returns keychain_write_failed. The
         config.toml entry is left behind (recoverable: user can re-key via
-        set-password --dialog later)."""
+        set-password --dialog later).
+
+        Per CWE-209 (round-5): raw str(e) is NOT in the response message —
+        only the exception class name + a sanitized hint."""
+        password_marker = "the-actual-password-this-must-never-leak"
         monkeypatch.setattr(
             'redshift_comment_mcp.config.write_profile',
             lambda name, **kw: None,
         )
         def failing_set(name, pw):
-            raise RuntimeError("keychain locked")
+            # Simulate a hypothetical buggy backend that includes the
+            # password in its exception args. The sanitisation logic must
+            # prevent this from reaching the MCP response regardless.
+            raise RuntimeError(f"backend rejected password {password_marker!r}")
         monkeypatch.setattr('redshift_comment_mcp.config.set_password', failing_set)
         monkeypatch.setattr(
             'redshift_comment_mcp.setup_cli._collect_password_via_dialog',
@@ -1761,7 +1784,49 @@ class TestSetupViaDialogTool:
         result = setup_via_dialog(host='h', user='u', dbname='d')
 
         assert result["error"] == "keychain_write_failed"
-        assert "locked" in result["message"]
+        assert result["exception_class"] == "RuntimeError"
+        # Hard security invariant: password must NEVER reach the response
+        import json
+        serialized = json.dumps(result)
+        assert password_marker not in serialized, (
+            "keychain_write_failed response leaked the password value "
+            "via the exception args — CWE-209 + LLM02:2025 regression"
+        )
+        # ...but message remains actionable
+        assert "--stdin" in result["message"]
+
+    def test_setup_via_dialog_keychain_specific_exception_hints(self, monkeypatch):
+        """Snyk guidance: catch specific keyring exception types where
+        possible. setup_via_dialog maps known exception class names to
+        tailored hint sentences so the agent sees a more useful diagnosis
+        than the generic fallback ("Underlying keychain write failed.")."""
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.write_profile',
+            lambda name, **kw: None,
+        )
+        monkeypatch.setattr(
+            'redshift_comment_mcp.setup_cli._collect_password_via_dialog',
+            lambda profile: ("pw", "ok"),
+        )
+
+        # Build a fake KeyringLocked exception class — what real keyring
+        # would raise on a locked backend. setup_via_dialog inspects
+        # type(e).__name__, so a class named KeyringLocked is enough.
+        class KeyringLocked(Exception):
+            pass
+
+        def failing_set(name, pw):
+            raise KeyringLocked()
+        monkeypatch.setattr('redshift_comment_mcp.config.set_password', failing_set)
+
+        tools = self._make_tools()
+        setup_via_dialog = _get_tool_fn(tools, 'setup_via_dialog')
+        result = setup_via_dialog(host='h', user='u', dbname='d')
+
+        assert result["exception_class"] == "KeyringLocked"
+        # Tailored hint, not the generic fallback
+        assert "locked" in result["message"].lower()
+        assert "unlock" in result["message"].lower()
 
     def test_setup_via_dialog_overwrites_existing_profile(self, monkeypatch):
         """Calling setup_via_dialog with an existing profile name should

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1684,7 +1684,12 @@ class TestSetupViaDialogTool:
         assert "--stdin" in msg
 
     def test_setup_via_dialog_missing_field_returns_error(self, monkeypatch):
-        """Empty host/user/dbname → reject without touching config or keychain."""
+        """Empty host/user/dbname → reject without touching config or keychain.
+
+        Schema-consistency check: missing_field carries `exception_class`
+        like the other `error: ...` responses (ValidationError sentinel,
+        no real underlying exception). Agents can pattern-match on a
+        single error-response shape across all error paths."""
         write_calls = []
         monkeypatch.setattr(
             'redshift_comment_mcp.config.write_profile',
@@ -1697,6 +1702,10 @@ class TestSetupViaDialogTool:
         result = setup_via_dialog(host='', user='u', dbname='d')
 
         assert result["error"] == "missing_field"
+        # Schema-consistency with not_configured / write_profile_failed /
+        # keychain_write_failed:
+        assert result["exception_class"] == "ValidationError"
+        assert "host" in result["message"]
         assert len(write_calls) == 0  # nothing was written
 
     # ===== additional coverage rounds (gap-fill) =====
@@ -2117,10 +2126,15 @@ class TestSetupViaDialogConnectionVerification:
         assert result["tested"] is True
         assert "succeeded" in result["message"].lower()
 
-    def test_connection_test_fails_returns_configured_but_connection_failed(self, monkeypatch):
+    def test_connection_test_fails_returns_configured_but_connection_failed(self, monkeypatch, caplog):
         """The keystone safety: profile fields and password were saved, but
         the connection test caught a mismatch. Agent should NOT declare
-        setup done; should re-prompt user."""
+        setup done; should re-prompt user.
+
+        Also verifies M3 polish — connection-test failure is logged
+        server-side at WARNING level (not just surfaced in the response)
+        so an operator looking at server.log later can correlate."""
+        import logging as _logging
         self._setup_common_mocks(monkeypatch)
         monkeypatch.setattr(
             'redshift_comment_mcp.setup_cli._test_redshift_connection',
@@ -2130,7 +2144,8 @@ class TestSetupViaDialogConnectionVerification:
         tools = self._make_tools()
         setup_via_dialog = _get_tool_fn(tools, 'setup_via_dialog')
 
-        result = setup_via_dialog(host='wrong.example.com', user='u', dbname='d')
+        with caplog.at_level(_logging.WARNING, logger='redshift_comment_mcp.redshift_tools'):
+            result = setup_via_dialog(host='wrong.example.com', user='u', dbname='d')
 
         assert result["status"] == "configured_but_connection_failed"
         assert result["tested"] is False
@@ -2139,6 +2154,18 @@ class TestSetupViaDialogConnectionVerification:
         assert "VPN" in result["message"] or "host" in result["message"].lower()
         # Profile name preserved so agent knows which one to re-setup
         assert result["profile"] == "default"
+        # M3: server-side WARNING log must include profile + cluster coords
+        # + the underlying connection error, so operators can debug
+        warning_records = [r for r in caplog.records if r.levelno == _logging.WARNING]
+        assert len(warning_records) >= 1, (
+            "connection-test failure must produce a server-side WARNING log "
+            "(was missing pre-round-7); operator-side debugging relied on "
+            "this entry"
+        )
+        log_text = " ".join(r.getMessage() for r in warning_records)
+        assert "default" in log_text  # profile name
+        assert "wrong.example.com" in log_text  # cluster host
+        assert "timed out" in log_text.lower()  # underlying error
 
     def test_connection_test_args_include_resolved_values(self, monkeypatch):
         """Verify _test_redshift_connection is called with the actual

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1603,6 +1603,49 @@ class TestSetupViaDialogTool:
         assert result["status"] == "dialog_unavailable"
         assert "--stdin" in result["message"]
 
+    def test_setup_via_dialog_permission_denied_status_carries_actionable_message(
+        self, monkeypatch
+    ):
+        """macOS Apple-Events permission denial returns a distinct
+        `permission_denied` status (NOT dialog_cancelled). The message
+        must give the agent actionable user instructions: open System
+        Settings → Privacy & Security → Automation, or run tccutil reset.
+        Without this distinction the agent would say "you cancelled the
+        dialog?" when actually the dialog never appeared."""
+        write_calls = []
+        set_pw_calls = []
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.write_profile',
+            lambda name, **kw: write_calls.append((name, kw)),
+        )
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.set_password',
+            lambda name, pw: set_pw_calls.append((name, pw)),
+        )
+        monkeypatch.setattr(
+            'redshift_comment_mcp.setup_cli._collect_password_via_dialog',
+            lambda profile: (None, "permission_denied"),
+        )
+
+        tools = self._make_tools()
+        setup_via_dialog = _get_tool_fn(tools, 'setup_via_dialog')
+
+        result = setup_via_dialog(host='h', user='u', dbname='d')
+
+        assert result["status"] == "permission_denied"
+        # Profile fields saved (recoverable state — same as cancelled)
+        assert len(write_calls) == 1
+        # Password NOT written
+        assert len(set_pw_calls) == 0
+        # Message must include the macOS-specific recovery path
+        msg = result["message"]
+        assert "Automation" in msg or "System Events" in msg
+        assert "System Settings" in msg or "Privacy" in msg
+        # Must NOT mislead agent into treating this as user cancellation
+        assert "cancelled" not in msg.lower()
+        # Fallback also mentioned for users who can't or won't grant permission
+        assert "--stdin" in msg
+
     def test_setup_via_dialog_missing_field_returns_error(self, monkeypatch):
         """Empty host/user/dbname → reject without touching config or keychain."""
         write_calls = []

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -54,7 +54,7 @@ def test_connection_management(mock_config):
     config, mock_conn = mock_config
     
     # 建立工具實例
-    redshift_tools = RedshiftTools(config)
+    redshift_tools = RedshiftTools(lambda: config)
     
     # 驗證 FastMCP 實例被建立
     assert redshift_tools.mcp is not None
@@ -74,7 +74,7 @@ def test_list_schemas_with_connection(mock_read_sql, mock_config):
     mock_read_sql.return_value = mock_df
     
     # 建立工具實例 - 這會觸發工具註冊
-    redshift_tools = RedshiftTools(config)
+    redshift_tools = RedshiftTools(lambda: config)
     
     # 驗證伺服器建立成功
     mcp_server = redshift_tools.get_server()
@@ -153,7 +153,7 @@ def test_redshift_tools_initialization():
     config = MagicMock()
     
     # 建立工具實例
-    redshift_tools = RedshiftTools(config)
+    redshift_tools = RedshiftTools(lambda: config)
     
     # 驗證屬性設定
     assert redshift_tools.config == config
@@ -247,7 +247,7 @@ class TestListToolsExecution:
         mock_df = pd.DataFrame({'schema_name': ['public', 'sales', 'analytics']})
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         # 取得註冊的工具函數
         list_schemas = _get_tool_fn(tools, 'list_schemas')
 
@@ -269,7 +269,7 @@ class TestListToolsExecution:
         })
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         list_schemas = _get_tool_fn(tools, 'list_schemas')
 
         result = list_schemas(include_comments=True)
@@ -292,7 +292,7 @@ class TestListToolsExecution:
         })
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         list_schemas = _get_tool_fn(tools, 'list_schemas')
 
         result = list_schemas(include_comments=True)
@@ -313,7 +313,7 @@ class TestListToolsExecution:
         })
         mock_read_sql.side_effect = [schema_df, tables_df]
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         list_tables = _get_tool_fn(tools, 'list_tables')
 
         result = list_tables(schema_name='sales', include_comments=False)
@@ -337,7 +337,7 @@ class TestListToolsExecution:
         })
         mock_read_sql.side_effect = [schema_df, tables_df]
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         list_tables = _get_tool_fn(tools, 'list_tables')
 
         result = list_tables(schema_name='sales', include_comments=True)
@@ -361,7 +361,7 @@ class TestListToolsExecution:
         })
         mock_read_sql.side_effect = [schema_df, tables_df]
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         list_tables = _get_tool_fn(tools, 'list_tables')
 
         result = list_tables(schema_name='sales', include_comments=True)
@@ -380,7 +380,7 @@ class TestListToolsExecution:
         })
         mock_read_sql.return_value = tables_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         list_tables = _get_tool_fn(tools, 'list_tables')
 
         result = list_tables(schema_name='sales', include_parent_comments=False)
@@ -405,7 +405,7 @@ class TestListToolsExecution:
         })
         mock_read_sql.side_effect = [table_df, columns_df]
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         list_columns = _get_tool_fn(tools, 'list_columns')
 
         result = list_columns(schema_name='sales', table_name='orders', include_comments=False)
@@ -430,7 +430,7 @@ class TestListToolsExecution:
         })
         mock_read_sql.side_effect = [table_df, columns_df]
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         list_columns = _get_tool_fn(tools, 'list_columns')
 
         result = list_columns(schema_name='sales', table_name='orders', include_comments=True)
@@ -456,7 +456,7 @@ class TestListToolsExecution:
         })
         mock_read_sql.side_effect = [table_df, columns_df]
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         list_columns = _get_tool_fn(tools, 'list_columns')
 
         result = list_columns(schema_name='sales', table_name='orders', include_comments=True)
@@ -476,7 +476,7 @@ class TestListToolsExecution:
         })
         mock_read_sql.return_value = columns_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         list_columns = _get_tool_fn(tools, 'list_columns')
 
         result = list_columns(schema_name='sales', table_name='orders', include_parent_comments=False)
@@ -505,7 +505,7 @@ class TestSearchTools:
         })
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         search_schemas = _get_tool_fn(tools, 'search_schemas')
 
         result = search_schemas(keywords='sales 銷售')
@@ -521,7 +521,7 @@ class TestSearchTools:
     def test_search_schemas_empty_keywords(self, mock_config):
         """測試 search_schemas 空關鍵字驗證"""
         config, mock_conn = mock_config
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
 
         search_schemas = _get_tool_fn(tools, 'search_schemas')
 
@@ -539,7 +539,7 @@ class TestSearchTools:
         })
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         search_schemas = _get_tool_fn(tools, 'search_schemas')
 
         result = search_schemas(keywords='public')
@@ -560,7 +560,7 @@ class TestSearchTools:
         })
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         search_schemas = _get_tool_fn(tools, 'search_schemas')
 
         # 搜尋 "sales data" - sales_data 應該命中兩個關鍵字
@@ -586,7 +586,7 @@ class TestSearchTools:
         })
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         search_tables = _get_tool_fn(tools, 'search_tables')
 
         # 搜尋 "order items" - order_items 應該命中兩個關鍵字
@@ -611,7 +611,7 @@ class TestSearchTools:
         })
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         search_columns = _get_tool_fn(tools, 'search_columns')
 
         # 搜尋 "total amount" - total_amount 應該命中兩個關鍵字
@@ -635,7 +635,7 @@ class TestSearchTools:
         })
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         search_tables = _get_tool_fn(tools, 'search_tables')
 
         result = search_tables(keywords='order 訂單', schema_name='sales')
@@ -647,7 +647,7 @@ class TestSearchTools:
     def test_search_tables_empty_keywords(self, mock_config):
         """測試 search_tables 空關鍵字驗證"""
         config, mock_conn = mock_config
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
 
         search_tables = _get_tool_fn(tools, 'search_tables')
 
@@ -657,7 +657,7 @@ class TestSearchTools:
     def test_search_tables_invalid_schema(self, mock_config):
         """測試 search_tables 無效 schema 名稱"""
         config, mock_conn = mock_config
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
 
         search_tables = _get_tool_fn(tools, 'search_tables')
 
@@ -678,7 +678,7 @@ class TestSearchTools:
         })
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         search_columns = _get_tool_fn(tools, 'search_columns')
 
         result = search_columns(keywords='customer', schema_name='sales', table_name='orders')
@@ -691,7 +691,7 @@ class TestSearchTools:
     def test_search_columns_invalid_table(self, mock_config):
         """測試 search_columns 無效 table 名稱"""
         config, mock_conn = mock_config
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
 
         search_columns = _get_tool_fn(tools, 'search_columns')
 
@@ -712,7 +712,7 @@ class TestCommentQueryTools:
         mock_df = pd.DataFrame({'schema_comment': ['This is the sales schema']})
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         get_schema_comment = _get_tool_fn(tools, 'get_schema_comment')
 
         result = get_schema_comment(schema_name='sales')
@@ -728,7 +728,7 @@ class TestCommentQueryTools:
         mock_df = pd.DataFrame(columns=['schema_comment'])  # 空的 DataFrame
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         get_schema_comment = _get_tool_fn(tools, 'get_schema_comment')
 
         with pytest.raises(ValueError, match="not found"):
@@ -742,7 +742,7 @@ class TestCommentQueryTools:
         mock_df = pd.DataFrame({'table_comment': ['Contains order records']})
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         get_table_comment = _get_tool_fn(tools, 'get_table_comment')
 
         result = get_table_comment(schema_name='sales', table_name='orders')
@@ -762,7 +762,7 @@ class TestCommentQueryTools:
         })
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         get_column_comment = _get_tool_fn(tools, 'get_column_comment')
 
         result = get_column_comment(schema_name='sales', table_name='orders', column_name='id')
@@ -786,7 +786,7 @@ class TestCommentQueryTools:
         })
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         get_all_column_comments = _get_tool_fn(tools, 'get_all_column_comments')
 
         result = get_all_column_comments(schema_name='sales', table_name='orders')
@@ -812,7 +812,7 @@ class TestExecuteSQL:
         })
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         execute_sql = _get_tool_fn(tools, 'execute_sql')
 
         result = execute_sql(sql_statement='SELECT * FROM users')
@@ -829,7 +829,7 @@ class TestExecuteSQL:
         mock_df = pd.DataFrame({'count': [10]})
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         execute_sql = _get_tool_fn(tools, 'execute_sql')
 
         result = execute_sql(sql_statement='WITH cte AS (SELECT * FROM users) SELECT count(*) FROM cte')
@@ -839,7 +839,7 @@ class TestExecuteSQL:
     def test_execute_sql_dangerous_drop(self, mock_config):
         """測試拒絕 DROP 語句"""
         config, mock_conn = mock_config
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
 
         execute_sql = _get_tool_fn(tools, 'execute_sql')
 
@@ -849,7 +849,7 @@ class TestExecuteSQL:
     def test_execute_sql_dangerous_delete(self, mock_config):
         """測試拒絕包含 DELETE 的查詢"""
         config, mock_conn = mock_config
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
 
         execute_sql = _get_tool_fn(tools, 'execute_sql')
 
@@ -860,7 +860,7 @@ class TestExecuteSQL:
     def test_execute_sql_invalid_start(self, mock_config):
         """測試拒絕非 SELECT/WITH 開頭的查詢"""
         config, mock_conn = mock_config
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
 
         execute_sql = _get_tool_fn(tools, 'execute_sql')
 
@@ -880,7 +880,7 @@ class TestExecuteSQL:
         """擋掉 v0.3.x 後新增的關鍵字（MERGE / GRANT / REVOKE / COPY / UNLOAD），
         含 CTE 偽裝（SELECT 開頭但 DML/admin 動作藏在後段）。"""
         config, _ = mock_config
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         execute_sql = _get_tool_fn(tools, 'execute_sql')
         with pytest.raises(ValueError, match=keyword):
             execute_sql(sql_statement=sql)
@@ -890,7 +890,7 @@ class TestExecuteSQL:
         """BOM 等不可見字元在 SQL 前不應誤觸 startswith 檢查。"""
         config, _ = mock_config
         mock_read_sql.return_value = pd.DataFrame({'x': [1]})
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         execute_sql = _get_tool_fn(tools, 'execute_sql')
         # 各種會出現在傳輸層或編輯器複製的不可見前綴
         for prefix in ('﻿', '​', ' ', '⁠'):
@@ -955,7 +955,7 @@ class TestErrorHandling:
     def test_list_tables_invalid_schema(self, mock_config):
         """測試 list_tables 無效 schema 名稱"""
         config, mock_conn = mock_config
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
 
         list_tables = _get_tool_fn(tools, 'list_tables')
 
@@ -965,7 +965,7 @@ class TestErrorHandling:
     def test_list_columns_invalid_table(self, mock_config):
         """測試 list_columns 無效 table 名稱"""
         config, mock_conn = mock_config
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
 
         list_columns = _get_tool_fn(tools, 'list_columns')
 
@@ -975,7 +975,7 @@ class TestErrorHandling:
     def test_get_column_comment_invalid_names(self, mock_config):
         """測試 get_column_comment 無效名稱"""
         config, mock_conn = mock_config
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
 
         get_column_comment = _get_tool_fn(tools, 'get_column_comment')
 
@@ -1069,7 +1069,7 @@ class TestListTablesIntegrationWithCapAndHint:
         })
         mock_read_sql.side_effect = [schema_df, tables_df]
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         list_tables = _get_tool_fn(tools, 'list_tables')
         result = list_tables(schema_name='big')
 
@@ -1088,7 +1088,7 @@ class TestListTablesIntegrationWithCapAndHint:
         })
         mock_read_sql.side_effect = [schema_df, tables_df]
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         list_tables = _get_tool_fn(tools, 'list_tables')
         result = list_tables(schema_name='small')
 
@@ -1106,7 +1106,7 @@ class TestListTablesIntegrationWithCapAndHint:
         })
         mock_read_sql.side_effect = [schema_df, tables_df]
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         list_tables = _get_tool_fn(tools, 'list_tables')
         result = list_tables(schema_name='s', include_comments=True)
 
@@ -1126,7 +1126,7 @@ class TestListTablesIntegrationWithCapAndHint:
         })
         mock_read_sql.side_effect = [schema_df, tables_df]
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         list_tables = _get_tool_fn(tools, 'list_tables')
         result = list_tables(schema_name='s', include_comments=True)
 
@@ -1144,7 +1144,7 @@ class TestSingleGetterDoesNotTruncate:
         mock_df = pd.DataFrame({'table_comment': [long_comment]})
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         get_table_comment = _get_tool_fn(tools, 'get_table_comment')
         result = get_table_comment(schema_name='s', table_name='t')
 
@@ -1159,7 +1159,7 @@ class TestSingleGetterDoesNotTruncate:
         mock_df = pd.DataFrame({'data_type': ['varchar'], 'column_comment': [long_comment]})
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         get_column_comment = _get_tool_fn(tools, 'get_column_comment')
         result = get_column_comment(schema_name='s', table_name='t', column_name='c')
 
@@ -1186,7 +1186,7 @@ class TestSearchToolsCrossScope:
         })
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         search_tables = _get_tool_fn(tools, 'search_tables')
 
         # No schema_name argument
@@ -1211,7 +1211,7 @@ class TestSearchToolsCrossScope:
         })
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         search_tables = _get_tool_fn(tools, 'search_tables')
 
         result = search_tables(keywords='order', schema_name='sales')
@@ -1222,7 +1222,7 @@ class TestSearchToolsCrossScope:
     def test_search_tables_invalid_schema_when_provided(self, mock_config):
         """Invalid schema_name still raises (only the None case is permitted to skip filter)."""
         config, _ = mock_config
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         search_tables = _get_tool_fn(tools, 'search_tables')
 
         with pytest.raises(ValueError, match="Invalid schema name"):
@@ -1248,7 +1248,7 @@ class TestSearchToolsCrossScope:
         })
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         search_columns = _get_tool_fn(tools, 'search_columns')
 
         # Omit table_name: schema-wide search
@@ -1276,7 +1276,7 @@ class TestSearchToolsCrossScope:
         })
         mock_read_sql.return_value = mock_df
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         search_columns = _get_tool_fn(tools, 'search_columns')
 
         result = search_columns(keywords='customer', schema_name='sales', table_name='orders')
@@ -1288,7 +1288,7 @@ class TestSearchToolsCrossScope:
     def test_search_columns_invalid_table_when_provided(self, mock_config):
         """Invalid table_name still raises (only the None case skips the filter)."""
         config, _ = mock_config
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         search_columns = _get_tool_fn(tools, 'search_columns')
 
         with pytest.raises(ValueError, match="Invalid table name"):
@@ -1298,7 +1298,7 @@ class TestSearchToolsCrossScope:
         """schema_name remains required even though table_name is now optional —
         cluster-wide column search would be too expensive on the leader node."""
         config, _ = mock_config
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         search_columns = _get_tool_fn(tools, 'search_columns')
 
         with pytest.raises(ValueError, match="Invalid schema name"):
@@ -1319,7 +1319,7 @@ class TestExecuteSqlTransparency:
         config, _ = mock_config
         mock_read_sql.return_value = pd.DataFrame({'x': [1]})
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         execute_sql = _get_tool_fn(tools, 'execute_sql')
         result = execute_sql(sql_statement="SELECT 1 AS x")
 
@@ -1332,7 +1332,7 @@ class TestExecuteSqlTransparency:
         config, _ = mock_config
         mock_read_sql.return_value = pd.DataFrame({'x': [1]})
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         execute_sql = _get_tool_fn(tools, 'execute_sql')
         result = execute_sql(sql_statement="SELECT 1 AS x")
 
@@ -1351,7 +1351,7 @@ class TestExecuteSqlTransparency:
         config, _ = mock_config
         mock_read_sql.return_value = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         execute_sql = _get_tool_fn(tools, 'execute_sql')
         result = execute_sql(sql_statement="SELECT a, b FROM t")
 
@@ -1372,7 +1372,7 @@ class TestExecuteSqlTransparency:
             'schema_name': ['public'], 'schema_comment': [None],
         })
 
-        tools = RedshiftTools(config)
+        tools = RedshiftTools(lambda: config)
         list_schemas = _get_tool_fn(tools, 'list_schemas')
         search_schemas = _get_tool_fn(tools, 'search_schemas')
         get_schema_comment = _get_tool_fn(tools, 'get_schema_comment')
@@ -1395,3 +1395,220 @@ class TestExecuteSqlTransparency:
         r = get_schema_comment(schema_name="public")
         assert "_executed_sql" not in r
         assert "_user_facing_message" not in r
+
+
+# ===== Degraded-mode startup (v0.7.0): no profile yet =====
+#
+# The server boots regardless of profile state. DB tools return a structured
+# not_configured error rather than letting the ConfigurationError crash
+# the process. The setup_via_dialog tool can bootstrap a profile in-session
+# without the password ever crossing the MCP wire.
+
+
+class TestDegradedModeContract:
+    """v0.7.0: server starts without profile; DB tools return error JSON."""
+
+    def test_db_tool_returns_not_configured_when_provider_raises(self):
+        """ConfigurationError from the lazy provider becomes a structured
+        tool response, not a propagating exception. This is the core
+        degraded-mode behavior — the server never crashes on missing profile."""
+        from redshift_comment_mcp.config import ConfigurationError
+
+        def failing_provider():
+            raise ConfigurationError(
+                "Profile 'default' is not configured. Configure via one of: ..."
+            )
+
+        tools = RedshiftTools(failing_provider)
+        list_schemas = _get_tool_fn(tools, 'list_schemas')
+
+        result = list_schemas()
+
+        assert result["error"] == "not_configured"
+        assert "default" in result["message"]
+        assert "setup_via_dialog" in result["next_step"]
+
+    def test_every_db_tool_handles_not_configured(self):
+        """All 11 DB tools should propagate the not_configured pattern.
+        Catches the case where a new tool is added without @_guarded."""
+        from redshift_comment_mcp.config import ConfigurationError
+
+        def failing_provider():
+            raise ConfigurationError("not configured")
+
+        tools = RedshiftTools(failing_provider)
+
+        # Tools that take no required args, or where we can pass minimal stubs
+        cases = [
+            ('list_schemas', {}),
+            ('list_tables', {'schema_name': 'x'}),
+            ('list_columns', {'schema_name': 'x', 'table_name': 'y'}),
+            ('search_schemas', {'keywords': 'k'}),
+            ('search_tables', {'keywords': 'k', 'schema_name': 'x'}),
+            ('search_columns', {'keywords': 'k', 'schema_name': 'x'}),
+            ('get_schema_comment', {'schema_name': 'x'}),
+            ('get_table_comment', {'schema_name': 'x', 'table_name': 'y'}),
+            ('get_column_comment', {'schema_name': 'x', 'table_name': 'y', 'column_name': 'z'}),
+            ('get_all_column_comments', {'schema_name': 'x', 'table_name': 'y'}),
+            ('execute_sql', {'sql_statement': 'SELECT 1'}),
+        ]
+        for tool_name, kwargs in cases:
+            fn = _get_tool_fn(tools, tool_name)
+            result = fn(**kwargs)
+            assert isinstance(result, dict), f"{tool_name} returned non-dict: {type(result)}"
+            assert result.get("error") == "not_configured", (
+                f"{tool_name} did not return not_configured (got: {result})"
+            )
+
+    def test_lazy_re_resolution_picks_up_new_config(self, mock_config):
+        """Provider is called per tool invocation, so config changes between
+        calls take effect without restart. First call raises (not configured),
+        second call returns a usable config → tool succeeds."""
+        from redshift_comment_mcp.config import ConfigurationError
+
+        config, mock_conn = mock_config
+        states = [ConfigurationError("first call: not configured"), config]
+        call_count = {'n': 0}
+
+        def stateful_provider():
+            idx = call_count['n']
+            call_count['n'] += 1
+            v = states[idx]
+            if isinstance(v, Exception):
+                raise v
+            return v
+
+        tools = RedshiftTools(stateful_provider)
+        list_schemas = _get_tool_fn(tools, 'list_schemas')
+
+        # First call: not configured
+        result1 = list_schemas()
+        assert result1.get("error") == "not_configured"
+
+        # Second call: provider now returns good config → tool runs
+        with patch('awswrangler.redshift.read_sql_query') as mock_read:
+            mock_read.return_value = pd.DataFrame({
+                'schema_name': ['public'],
+                'schema_comment': ['ok'],
+            })
+            result2 = list_schemas()
+        assert "schemas" in result2 or "items" in result2 or not isinstance(result2.get("error"), str), (
+            f"Second call should have succeeded but got: {result2}"
+        )
+        assert call_count['n'] == 2  # provider called once per tool invocation
+
+
+# ===== setup_via_dialog MCP tool (v0.7.0) =====
+
+
+class TestSetupViaDialogTool:
+    """In-band profile bootstrap via MCP tool. Password collection happens
+    via OS-native dialog server-side; never crosses MCP wire."""
+
+    def _make_tools(self, provider=None):
+        """Build a RedshiftTools instance with a no-op provider by default
+        (setup_via_dialog doesn't need the provider to succeed)."""
+        from redshift_comment_mcp.config import ConfigurationError
+
+        if provider is None:
+            def provider():
+                raise ConfigurationError("not yet")
+        return RedshiftTools(provider)
+
+    def test_setup_via_dialog_works_without_configured_profile(self, monkeypatch):
+        """setup_via_dialog is the bootstrap tool — it MUST NOT be gated by
+        the @_guarded decorator (it has to run before a profile exists)."""
+        write_calls = []
+        set_pw_calls = []
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.write_profile',
+            lambda name, **kw: write_calls.append((name, kw)),
+        )
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.set_password',
+            lambda name, pw: set_pw_calls.append((name, pw)),
+        )
+        monkeypatch.setattr(
+            'redshift_comment_mcp.setup_cli._collect_password_via_dialog',
+            lambda profile: ("dialog-secret", "ok"),
+        )
+
+        tools = self._make_tools()  # provider raises ConfigurationError
+        setup_via_dialog = _get_tool_fn(tools, 'setup_via_dialog')
+
+        result = setup_via_dialog(
+            host='h.example.com',
+            user='alice',
+            dbname='analytics',
+            profile='prod',
+            port=5439,
+        )
+
+        assert result["status"] == "configured", f"got: {result}"
+        assert result["profile"] == "prod"
+        assert write_calls == [
+            ('prod', {'host': 'h.example.com', 'port': 5439,
+                      'user': 'alice', 'dbname': 'analytics'}),
+        ]
+        assert set_pw_calls == [('prod', 'dialog-secret')]
+
+    def test_setup_via_dialog_dialog_cancelled_status(self, monkeypatch):
+        """User clicked Cancel → profile fields are still written (recoverable
+        state) but no password is set."""
+        write_calls = []
+        set_pw_calls = []
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.write_profile',
+            lambda name, **kw: write_calls.append((name, kw)),
+        )
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.set_password',
+            lambda name, pw: set_pw_calls.append((name, pw)),
+        )
+        monkeypatch.setattr(
+            'redshift_comment_mcp.setup_cli._collect_password_via_dialog',
+            lambda profile: (None, "cancelled"),
+        )
+
+        tools = self._make_tools()
+        setup_via_dialog = _get_tool_fn(tools, 'setup_via_dialog')
+
+        result = setup_via_dialog(host='h', user='u', dbname='d')
+
+        assert result["status"] == "dialog_cancelled"
+        assert len(write_calls) == 1  # fields were written
+        assert len(set_pw_calls) == 0  # password was NOT written
+
+    def test_setup_via_dialog_dialog_unavailable_hints_stdin(self, monkeypatch):
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.write_profile',
+            lambda name, **kw: None,
+        )
+        monkeypatch.setattr(
+            'redshift_comment_mcp.setup_cli._collect_password_via_dialog',
+            lambda profile: (None, "unavailable"),
+        )
+
+        tools = self._make_tools()
+        setup_via_dialog = _get_tool_fn(tools, 'setup_via_dialog')
+
+        result = setup_via_dialog(host='h', user='u', dbname='d')
+
+        assert result["status"] == "dialog_unavailable"
+        assert "--stdin" in result["message"]
+
+    def test_setup_via_dialog_missing_field_returns_error(self, monkeypatch):
+        """Empty host/user/dbname → reject without touching config or keychain."""
+        write_calls = []
+        monkeypatch.setattr(
+            'redshift_comment_mcp.config.write_profile',
+            lambda name, **kw: write_calls.append((name, kw)),
+        )
+
+        tools = self._make_tools()
+        setup_via_dialog = _get_tool_fn(tools, 'setup_via_dialog')
+
+        result = setup_via_dialog(host='', user='u', dbname='d')
+
+        assert result["error"] == "missing_field"
+        assert len(write_calls) == 0  # nothing was written

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1428,6 +1428,32 @@ class TestDegradedModeContract:
         assert "default" in result["message"]
         assert "setup_via_dialog" in result["next_step"]
 
+    def test_not_configured_response_schema_matches_setup_via_dialog_errors(self):
+        """Schema consistency: not_configured response must carry the same
+        `exception_class` field as setup_via_dialog's error responses
+        (write_profile_failed / keychain_write_failed). Without this, agents
+        have to special-case different error-response shapes from related
+        tools — schema discipline that round-6 polish brought in."""
+        from redshift_comment_mcp.config import ConfigurationError
+
+        def failing_provider():
+            raise ConfigurationError("anything")
+
+        tools = RedshiftTools(failing_provider)
+        list_schemas = _get_tool_fn(tools, 'list_schemas')
+        result = list_schemas()
+
+        # Required fields for the unified error-response schema:
+        assert "error" in result
+        assert "exception_class" in result, (
+            "not_configured response missing exception_class field — "
+            "schema diverges from setup_via_dialog's error responses"
+        )
+        assert result["exception_class"] == "ConfigurationError"
+        assert "message" in result
+        # not_configured-specific:
+        assert "next_step" in result
+
     def test_every_db_tool_handles_not_configured(self):
         """All 11 DB tools should propagate the not_configured pattern.
         Catches the case where a new tool is added without @_guarded."""
@@ -1462,40 +1488,51 @@ class TestDegradedModeContract:
 
     def test_lazy_re_resolution_picks_up_new_config(self, mock_config):
         """Provider is called per tool invocation, so config changes between
-        calls take effect without restart. First call raises (not configured),
-        second call returns a usable config → tool succeeds."""
+        calls take effect without restart. First call: state says
+        unconfigured, provider raises, tool returns not_configured. Flip
+        state. Second call: provider returns valid config, tool runs.
+
+        State-based provider (vs. list-of-states indexed by call count)
+        is robust to tools that access ``self.config`` more than once per
+        invocation — the property invocations all see the same external
+        state instead of marching off the end of a list."""
         from redshift_comment_mcp.config import ConfigurationError
 
         config, mock_conn = mock_config
-        states = [ConfigurationError("first call: not configured"), config]
-        call_count = {'n': 0}
+        state = {"configured": False}
 
         def stateful_provider():
-            idx = call_count['n']
-            call_count['n'] += 1
-            v = states[idx]
-            if isinstance(v, Exception):
-                raise v
-            return v
+            if state["configured"]:
+                return config
+            raise ConfigurationError("provider says: not configured yet")
 
         tools = RedshiftTools(stateful_provider)
         list_schemas = _get_tool_fn(tools, 'list_schemas')
 
-        # First call: not configured
+        # 1st call: state is unconfigured → tool returns not_configured
         result1 = list_schemas()
         assert result1.get("error") == "not_configured"
 
-        # Second call: provider now returns good config → tool runs
+        # Flip external state — simulates setup_via_dialog / CLI setup
+        # writing config.toml + keychain in between tool calls.
+        state["configured"] = True
+
+        # 2nd call: provider now returns the good config → tool runs.
+        # No reset of any indexes, no fragile call-count assertion.
         with patch('awswrangler.redshift.read_sql_query') as mock_read:
             mock_read.return_value = pd.DataFrame({
                 'schema_name': ['public'],
                 'schema_comment': ['ok'],
             })
             result2 = list_schemas()
-        assert "schemas" in result2 or "items" in result2 or not isinstance(result2.get("error"), str), (
-            f"Second call should have succeeded but got: {result2}"
+        assert result2.get("error") != "not_configured", (
+            f"Second call should have picked up the new state via lazy "
+            f"resolution, but got: {result2}"
         )
-        assert call_count['n'] == 2  # provider called once per tool invocation
+        assert "schemas" in result2 or "items" in result2, (
+            f"Second call should return schema data, got keys: "
+            f"{list(result2.keys())}"
+        )
 
 
 # ===== setup_via_dialog MCP tool (v0.7.0) =====


### PR DESCRIPTION
## Summary

Completes the agent setup UX trajectory started by v0.6.0's `set-password --dialog`. v0.6.0 still required: agent reads MCP client log → uses Bash tool → restarts MCP client. v0.7.0 collapses that to **pure MCP, 3 steps, no Bash, no restart**.

```
v0.7.0 agent flow:
  agent: list_schemas()  → {"error": "not_configured", "next_step": "Call setup_via_dialog..."}
  agent: setup_via_dialog(host=..., user=..., dbname=...)
                         → OS dialog appears, user types password
                         → {"status": "configured"}
  agent: list_schemas()  → works (lazy resolve picks up new profile, no restart)
```

## Three composing changes

### 1. Degraded-mode startup ([server.py](src/redshift_comment_mcp/server.py))
Server boots **regardless of profile state**. `resolve_connection_params` now raises `ConfigurationError` (a `ValueError` subclass for backward-compat). `main()` no longer calls it upfront — instead builds a `lazy_config_provider` closure and passes it to `RedshiftTools`. Per-call re-resolution means newly-written profiles take effect on the next tool call (no MCP client restart).

### 2. Tool-level guard ([redshift_tools.py](src/redshift_comment_mcp/redshift_tools.py))
New `@_guarded` decorator stacks above `@self.mcp.tool` on all 11 DB tools. Catches `ConfigurationError` and returns `{"error": "not_configured", "message": ..., "next_step": ...}` to the agent. Existing tool bodies are **byte-identical** — only the surrounding decorator stack changed. `execute_sql` got a small tweak: `self.config` access hoisted out of its broad `try/except Exception` so `ConfigurationError` reaches `@_guarded` instead of being swallowed by the SQL-error wrapper.

### 3. New `setup_via_dialog` MCP tool
Bootstraps a profile in-session. Agent passes host/port/user/dbname as args (non-secret). Tool writes `config.toml`, then launches OS-native password dialog server-side via the same `_collect_password_via_dialog()` helper that backs `set-password --dialog`. Password captured into Python string in-process via `subprocess.run(capture_output=True)`, written directly to OS keychain. **Never crosses MCP wire, never appears in tool args, never reaches chat.**

Returns structured states: `configured` / `dialog_cancelled` / `dialog_unavailable` / `platform_unsupported` / `empty_password` / `missing_field`. Each carries a `message` field telling the agent what to do next.

## FastMCP `instructions=` extended

New "SETUP RECOVERY" section in the handshake-time instructions describes the degraded-mode contract so agents see the recovery path even before they hit a `not_configured` error.

## Tools: 11 → 12

`setup_via_dialog` added. Tools table + count updated in [README.md](README.md) / [README.ja.md](README.ja.md) / [README.zh-TW.md](README.zh-TW.md). The "Setting up with uvx" → "code-agent bootstrap" section in all 3 READMEs now leads with the in-band MCP tool flow and lists the Bash + --stdin CLI as headless-only fallback.

## Test coverage

| Tier | Before | After | New tests |
|---|---|---|---|
| Unit | 264 passed, 2 skipped | **271 passed, 2 skipped** | +7 |
| Integration (live cluster) | 22 passed, 1 skipped | 22 passed, 1 skipped | unchanged shape |
| E2E (MCP wire) | 4 passed | 4 passed | unchanged |

Backward-compat test refactor: 58 existing `RedshiftTools(config)` call sites mechanically rewritten to `RedshiftTools(lambda: config)` because Mock objects defeat both `callable()` and `hasattr()` runtime detection (see commit body's Gotcha trailer).

## Test plan

- [x] `pytest tests/ --ignore=tests/integration --ignore=tests/e2e` → 271 passed / 2 skipped
- [x] `REDSHIFT_INTEGRATION=1 pytest tests/integration tests/e2e` → 26 passed / 1 env-skip (via VPN to ichef cluster)
- [x] Version sync: `plugin.json` 0.7.0 == `pyproject.toml` fallback_version 0.7.0
- [x] Trilingual README parity: 12 tools in all 3 + new agent-bootstrap section in all 3
- [ ] Post-merge: tag v0.7.0 → Pre-release → flip to Release → PyPI (the publish.yml trigger fix from v0.6.0 should make this seamless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)