### PR TITLE
chore(release): idempotent publish workflows + bump 0.7.0 → 0.7.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redshift-comment-mcp",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Redshift MCP server with comment-first exploration. 11 tools for schema/table/column listing, hit-count keyword search, and SELECT-only SQL. Comments are authoritative — names are unreliable. Zero-config install: run `/redshift-comment-mcp:redshift-setup` in chat after install — host / user / database via Q&A, password via system dialog (never enters chat), connection verified. Multi-cluster via `/redshift-setup <name>` then `/redshift-switch-profile`.",
   "author": {
     "name": "kouko",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,7 +71,13 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
         echo "🚀 Publishing to PyPI..."
-        twine upload dist/* --verbose
+        # --skip-existing for idempotent re-runs (same rationale as
+        # test-publish.yml — see comment there). Even though PyPI's
+        # publish path is only meant to fire once per `released` event,
+        # workflow_dispatch + accidental re-runs would otherwise fail
+        # with a 400 duplicate-version error and surface as a misleading
+        # "release broken" badge on the GH Release page.
+        twine upload --skip-existing dist/* --verbose
         echo "✅ Published to PyPI successfully!"
     
     - name: Verify PyPI publication

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -63,7 +63,15 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
       run: |
         echo "📦 Publishing to TestPyPI..."
-        twine upload --repository testpypi dist/* --verbose
+        # --skip-existing makes the publish step idempotent: re-running this
+        # job after a previous successful upload (e.g. when an earlier
+        # downstream step like "Test installation" failed due to TestPyPI
+        # CDN propagation lag) no longer fails with a 400 Bad Request from
+        # the duplicate-version check. Without this flag, re-runs of the
+        # workflow are impossible — once a version is on TestPyPI, the only
+        # path to a green run was bumping the version number. See v0.7.0
+        # incident for the worked example.
+        twine upload --skip-existing --repository testpypi dist/* --verbose
         echo "✅ Published to TestPyPI successfully!"
     
     - name: Verify TestPyPI publication
@@ -101,17 +109,39 @@ jobs:
         echo "🧪 Testing installation from TestPyPI..."
         PACKAGE_NAME="redshift-comment-mcp"
         VERSION="${{ steps.get_version.outputs.version }}"
-        
+
         # 建立新的虛擬環境進行測試
         python -m venv test_env
         source test_env/bin/activate
-        
-        # 從 TestPyPI 安裝
-        pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "$PACKAGE_NAME==$VERSION"
-        
+
+        # TestPyPI's simple index (which pip uses) is served from a
+        # different CDN layer than the JSON API used by the previous
+        # "Verify" step. The simple index typically lags the JSON API by
+        # 1-3 minutes after upload. Without a retry loop here, a workflow
+        # run that finishes ~30s after upload (the common case) fails
+        # spuriously with "Could not find a version that satisfies the
+        # requirement". Retry up to 6 times with 30s backoff (3 min total)
+        # — covers the worst-case propagation seen in v0.7.0 incident.
+        echo "⏳ Retrying pip install up to 6× to absorb TestPyPI simple-index propagation lag..."
+        for i in 1 2 3 4 5 6; do
+          if pip install \
+               --index-url https://test.pypi.org/simple/ \
+               --extra-index-url https://pypi.org/simple/ \
+               "$PACKAGE_NAME==$VERSION"; then
+            echo "✅ pip install succeeded on attempt $i"
+            break
+          fi
+          if [ $i -eq 6 ]; then
+            echo "❌ pip install failed after 6 attempts (3min); TestPyPI simple index may be stuck"
+            exit 1
+          fi
+          echo "⏳ Attempt $i failed; sleeping 30s before retry..."
+          sleep 30
+        done
+
         # 測試命令是否可用
         redshift-comment-mcp --help
-        
+
         echo "✅ Installation test passed!"
     
     - name: Create Test Report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,4 +50,4 @@ redshift-comment-mcp = "redshift_comment_mcp.server:main"
 # .claude-plugin/plugin.json 的 "version" 欄位一同更新。
 [tool.setuptools_scm]
 write_to = "src/redshift_comment_mcp/_version.py"
-fallback_version = "0.7.0"
+fallback_version = "0.7.1"


### PR DESCRIPTION
## Summary

The v0.7.0 release attempt exposed two workflow flaws that made the GH Release page show a misleading "failed" badge despite TestPyPI actually having 0.7.0. This PR pivots to a clean v0.7.1 ship by (a) fixing the workflows so re-runs work and propagation lag is absorbed, and (b) bumping the version to 0.7.1 (mirroring the v0.4.0/v0.5.0 → v0.6.0 catch-up pattern).

## The two workflow flaws

### Flaw 1: `test-publish.yml` doesn't absorb TestPyPI propagation lag

The previous v0.7.0 run failed at \"Test installation from TestPyPI\":

```
ERROR: Could not find a version that satisfies the requirement redshift-comment-mcp==0.7.0
(from versions: 0.1.0a0, ..., 0.6.0)
```

Root cause: TestPyPI's [simple index](https://test.pypi.org/simple/redshift-comment-mcp/) (which `pip` uses) is served from a different CDN layer than the JSON API used by the preceding \"Verify\" step. Simple index typically lags the JSON API by 1-3 minutes. The workflow's install step ran ~30s after upload — pip couldn't see 0.7.0 yet.

**Fix**: wrap the `pip install` in a retry loop with 30s backoff × 6 attempts (3 min total).

### Flaw 2: twine upload not idempotent

A `gh run rerun --failed` on the v0.7.0 workflow hit:

```
HTTPError: 400 Bad Request from https://test.pypi.org/legacy/
```

because TestPyPI rejects duplicate-version uploads. Once a workflow successfully uploads, **no re-run can ever succeed** — the only path to a green workflow is bumping the version number (i.e. ship v0.7.1, can't re-ship v0.7.0).

**Fix**: add `--skip-existing` to the twine upload commands in **both** `test-publish.yml` AND `publish.yml`. Makes re-runs succeed cleanly when the version already exists.

## Why version bump in the same PR

CLAUDE.md says "always bump on the same PR as the user-visible change" — the workflow fix IS the user-visible change. Without it, bumping to 0.7.1 alone would walk the same failure path on the next release. Bundling makes the lesson stick.

User impact: `pip install --upgrade redshift-comment-mcp` skips from 0.6.0 directly to 0.7.1 (0.7.0 was never on PyPI). v0.7.1 = v0.7.0 + this workflow fix; functionally identical from the user perspective.

## Test plan

- [x] Unit tests: 299 passed / 2 skipped (workflow YAML changes don't affect Python tests; version-sync invariant test confirms plugin.json + pyproject.toml are both 0.7.1)
- [ ] Post-merge: tag v0.7.1 on the merge commit → Pre-release → watch test-publish.yml run cleanly (now with retry + idempotent upload) → flip to Release → publish.yml runs cleanly → verify PyPI 0.7.1 live
- [ ] Edit v0.7.0 GH Release notes with superseded warning pointing at v0.7.1 (same pattern as v0.5.0 supersede in PR #33's release flow)

## Forward-looking

- Backlog: bump `actions/checkout@v4` + `actions/setup-python@v4` to v5 to silence the Node.js 20 deprecation warnings (force-upgrade to Node 24 on 2026-06-02 per GitHub Actions roadmap). Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)