### PR TITLE
feat(plugin): default-disabled install (opt-in connector)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "redshift-comment-mcp",
-  "version": "0.8.0",
+  "version": "0.9.0",
+  "defaultEnabled": false,
   "description": "Redshift MCP server with comment-first exploration. 11 tools for schema/table/column listing, hit-count keyword search, and SELECT-only SQL. Comments are authoritative — names are unreliable. Zero-config install: run `/redshift-comment-mcp:redshift-setup` in chat after install — host / user / database via Q&A, password via system dialog (never enters chat), connection verified. Multi-cluster via `/redshift-setup <name>` then `/redshift-switch-profile`.",
   "author": {
     "name": "kouko",

--- a/README.ja.md
+++ b/README.ja.md
@@ -75,8 +75,11 @@ list / search はすべてページング対応。コメントを読んでから
 # 1. マーケットプレイスを登録（初回のみ）
 claude plugin marketplace add kouko/redshift-comment-mcp
 
-# 2. プラグインをインストール
+# 2. プラグインをインストール（外部サービスに接続するため、無効状態で導入＝オプトイン）
 claude plugin install redshift-comment-mcp
+
+# 3. 有効化 — このとき接続ダイアログが出ます
+claude plugin enable redshift-comment-mcp
 ```
 
 プラグインを**有効化**すると、Claude Code が host / port（デフォルト

--- a/README.md
+++ b/README.md
@@ -75,8 +75,11 @@ The fastest path is the Claude Code plugin.
 # 1. Register the marketplace (one-time)
 claude plugin marketplace add kouko/redshift-comment-mcp
 
-# 2. Install the plugin
+# 2. Install the plugin (ships DISABLED — opt-in, since it connects to an external service)
 claude plugin install redshift-comment-mcp
+
+# 3. Enable it — this is when the connection dialog appears
+claude plugin enable redshift-comment-mcp
 ```
 
 When you **enable** the plugin, Claude Code shows a connection dialog

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -70,8 +70,11 @@ manifest 涵蓋面太窄、Web GUI 太慢、手刻 SQL 太重複。
 # 1. 註冊 marketplace（一次性）
 claude plugin marketplace add kouko/redshift-comment-mcp
 
-# 2. 安裝 plugin
+# 2. 安裝 plugin（因為會連外部服務，預設「停用」安裝 = opt-in）
 claude plugin install redshift-comment-mcp
+
+# 3. 啟用它 —— 此時才會跳出連線對話框
+claude plugin enable redshift-comment-mcp
 ```
 
 當你**啟用** plugin 時，Claude Code 會跳出連線對話框，問你 host /

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,4 +50,4 @@ redshift-comment-mcp = "redshift_comment_mcp.server:main"
 # .claude-plugin/plugin.json 的 "version" 欄位一同更新。
 [tool.setuptools_scm]
 write_to = "src/redshift_comment_mcp/_version.py"
-fallback_version = "0.8.0"
+fallback_version = "0.9.0"

--- a/tests/test_repo_invariants.py
+++ b/tests/test_repo_invariants.py
@@ -253,6 +253,26 @@ def test_plugin_manifest_mcp_args_inject_userconfig_no_profile_flag():
     )
 
 
+def test_plugin_manifest_default_disabled():
+    """Opt-in install: an external-service connector MUST ship
+    `defaultEnabled: false` so it installs DISABLED and the user enables it
+    deliberately — the moment the userConfig connection dialog appears.
+
+    Grounded in fail-safe defaults (disable what connects out / costs money
+    by default) and Claude Code's own guidance — `defaultEnabled: false` is
+    recommended "for plugins that connect to an external service"
+    (plugins-reference §Default enablement). The field exists since Claude
+    Code v2.1.154; older clients ignore it and install enabled (the
+    pre-existing behavior), so setting it is downside-free."""
+    plugin = json.loads(PLUGIN_JSON.read_text())
+    assert plugin.get("defaultEnabled") is False, (
+        "plugin.json must set `defaultEnabled: false` — this plugin spawns an "
+        "MCP server that connects to Redshift (an external service), so it "
+        "should install disabled and be enabled opt-in. "
+        f"Got defaultEnabled={plugin.get('defaultEnabled')!r}."
+    )
+
+
 # ===== README trilingual parity =====
 
 @pytest.mark.parametrize("skill", _skill_dirs())


### PR DESCRIPTION
## What

Ships `defaultEnabled: false` in `plugin.json` so the plugin installs **disabled** and the user enables it deliberately — which is exactly when the v0.8.0 `userConfig` connection dialog appears.

## Why (industry-grounded)

This plugin spawns an MCP server that **connects to an external service** (Redshift) and needs credentials. Across three independent signals, that category should be **opt-in**:

- **Fail-safe defaults** — disable what connects out / costs by default to minimize attack surface ([secure-design principle](https://trustedinstitute.com/concept/comptia-security-plus/secure-system-design-principles/fail-safe-defaults/)); e.g. Microsoft Power Platform ships new connectors [disabled by default](https://learn.microsoft.com/en-us/power-platform/admin/connector-off-by-default) in gov clouds.
- **Claude Code's own guidance** — `defaultEnabled: false` is recommended "for plugins that connect to an external service" (plugins-reference §Default enablement). The field was added in v2.1.154 specifically to close this gap ([issue #27105](https://github.com/anthropics/claude-code/issues/27105)); the community repeatedly files MCP-connector auto-enablement as a bug ([#20412](https://github.com/anthropics/claude-code/issues/20412), [#50062](https://github.com/anthropics/claude-code/issues/50062)).
- **Eager-connect nuance** — unlike a VS Code extension (enabled-but-lazy), an MCP server is spawned and attempts to connect once enabled, so "enabled by default" ≈ "eager connect" — tilting further toward opt-in.

Default-enablement defaults to `true` when unset, so v0.8.0 installed **enabled**; this corrects that for the connector category. Non-breaking: existing users with an `enabledPlugins` entry are unaffected (user setting takes precedence and persists). Older Claude Code (<v2.1.154) ignores the field and installs enabled — downside-free.

## Changes
- `plugin.json` — `"defaultEnabled": false`.
- `tests/test_repo_invariants.py` — guard test for the opt-in contract (RED→GREEN).
- READMEs ×3 — add the explicit `claude plugin enable` step.
- Version `0.8.0 → 0.9.0` (MINOR — user-visible behavior change; both version fields).

## Verification
- ✅ Unit suite: **313 passed, 2 skipped** (new guard test included).
- Small, self-reviewed follow-up to PR #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)